### PR TITLE
[parser]: Add support for GROUP BY ALL syntax

### DIFF
--- a/pkg/format/select.go
+++ b/pkg/format/select.go
@@ -257,7 +257,21 @@ func (f *Formatter) formatWhereClause(where *parser.WhereClause) string {
 
 // formatGroupByClause formats GROUP BY clause
 func (f *Formatter) formatGroupByClause(groupBy *parser.GroupByClause) string {
-	if groupBy == nil || len(groupBy.Columns) == 0 {
+	if groupBy == nil {
+		return ""
+	}
+
+	// Handle GROUP BY ALL
+	if groupBy.All {
+		result := f.keyword("GROUP BY") + " " + f.keyword("ALL")
+		if groupBy.WithClause != nil {
+			result += " " + f.keyword("WITH") + " " + f.keyword(*groupBy.WithClause)
+		}
+		return result
+	}
+
+	// Handle regular GROUP BY with columns
+	if len(groupBy.Columns) == 0 {
 		return ""
 	}
 

--- a/pkg/format/testdata/group_by_all.in.sql
+++ b/pkg/format/testdata/group_by_all.in.sql
@@ -1,0 +1,1 @@
+SELECT domain, browser, count(*) as total FROM events WHERE date >= '2024-01-01' GROUP BY ALL;

--- a/pkg/format/testdata/group_by_all.sql
+++ b/pkg/format/testdata/group_by_all.sql
@@ -1,0 +1,7 @@
+SELECT
+    `domain`,
+    `browser`,
+    count(*) AS `total`
+FROM `events`
+WHERE `date` >= '2024-01-01'
+GROUP BY ALL;

--- a/pkg/parser/query.go
+++ b/pkg/parser/query.go
@@ -115,7 +115,8 @@ type (
 	// GroupByClause represents GROUP BY clause
 	GroupByClause struct {
 		GroupBy    string       `parser:"'GROUP' 'BY'"`
-		Columns    []Expression `parser:"@@ (',' @@)*"`
+		All        bool         `parser:"(@'ALL'"`
+		Columns    []Expression `parser:"| @@ (',' @@)*)"`
 		WithClause *string      `parser:"('WITH' @('CUBE' | 'ROLLUP' | 'TOTALS'))?"`
 	}
 

--- a/pkg/parser/testdata/query_group_by_all.sql
+++ b/pkg/parser/testdata/query_group_by_all.sql
@@ -1,0 +1,7 @@
+SELECT 
+    domain,
+    browser,
+    count(*) as total
+FROM events
+WHERE date >= '2024-01-01'
+GROUP BY ALL;

--- a/pkg/parser/testdata/query_group_by_all.yaml
+++ b/pkg/parser/testdata/query_group_by_all.yaml
@@ -1,0 +1,6 @@
+queries:
+    - columns:
+        - non_wildcard
+      from: events
+      has_where: true
+      has_group_by: true

--- a/pkg/parser/testdata/view_materialized_group_by_all.sql
+++ b/pkg/parser/testdata/view_materialized_group_by_all.sql
@@ -1,0 +1,18 @@
+CREATE MATERIALIZED VIEW `demo`.`events_by_hour_mv` ON CLUSTER `test`
+TO `demo`.`events_by_hour_local`
+AS SELECT
+    toStartOfHour(`event_received_at`) AS `received_at`,
+    `domain` AS `pv_domain`,
+    `browser` AS `pv_browser`,
+    `browser_version` AS `pv_browser_version`,
+    `os` AS `pv_os`,
+    `os_version` AS `pv_os_version`,
+    `country_code` AS `pv_country_code`,
+    `region_code` AS `pv_region_code`,
+    `event_url` AS `current_url`,
+    sumState(toUInt32(1)) AS `count`,
+    uniqState(`browser_id`) AS `users`,
+    uniqState(`page_visit_id`) AS `visits`
+FROM `demo`.`events`
+WHERE `event_type` = 'browser'
+GROUP BY ALL;

--- a/pkg/parser/testdata/view_materialized_group_by_all.yaml
+++ b/pkg/parser/testdata/view_materialized_group_by_all.yaml
@@ -1,0 +1,7 @@
+views:
+    - name: '`events_by_hour_mv`'
+      database: '`demo`'
+      cluster: '`test`'
+      materialized: true
+      operation: CREATE
+      to: '`demo`.`events_by_hour_local`'


### PR DESCRIPTION
ClickHouse supports GROUP BY ALL which automatically groups by all non-aggregate columns in the SELECT clause. This is a convenient shorthand that avoids having to explicitly list all grouping columns.

The parser was failing on statements like:
  SELECT domain, browser, count(*) FROM events GROUP BY ALL

This change adds support for parsing and formatting the GROUP BY ALL syntax by:

- Adding an `All` boolean field to GroupByClause to detect GROUP BY ALL usage
- Updating the formatter to properly output GROUP BY ALL when the flag is set
- Adding test coverage for both simple queries and materialized views using GROUP BY ALL