### PR TITLE
[schema]: Add named collections DDL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,42 @@ Rather than wait for Atlas to catch up with ClickHouse's unique requirements, Ho
 
 ## Key Features
 
-- **Complete ClickHouse DDL Support** - Full support for databases, tables, dictionaries, views, and materialized views
+- **Complete ClickHouse DDL Support** - Full support for databases, tables, dictionaries, views, materialized views, and named collections
 - **Cluster-Aware Operations** - Native `ON CLUSTER` support for distributed ClickHouse deployments
-- **Intelligent Migration Generation** - Smart schema comparison with proper operation ordering
+- **Intelligent Migration Generation** - Smart schema comparison with proper operation ordering and dependency management
 - **Modern Parser Architecture** - Built with participle for robust, maintainable SQL parsing
 - **Professional SQL Formatting** - Clean, consistent output optimized for ClickHouse
 - **Comprehensive Testing** - Extensive test suite with 100% DDL operation coverage
+
+## Supported Migration Operations
+
+| Object Type | CREATE | ALTER | ATTACH | DETACH | DROP | RENAME | Notes |
+|------------|--------|-------|---------|---------|------|--------|-------|
+| **Database** | ✅ | ✅¹ | ✅ | ✅ | ✅ | ✅ | ¹Comment changes only |
+| **Named Collection** | ✅ | ❌² | ❌ | ❌ | ✅ | ✅ | ²Uses CREATE OR REPLACE |
+| **Table** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Full ALTER support |
+| **Dictionary** | ✅ | ❌³ | ✅ | ✅ | ✅ | ✅ | ³Uses CREATE OR REPLACE |
+| **View** | ✅ | ❌⁴ | ✅ | ✅ | ✅ | ✅⁵ | ⁴Uses CREATE OR REPLACE |
+| **Materialized View** | ✅ | ❌⁶ | ✅⁷ | ✅⁷ | ✅⁷ | ✅⁷ | ⁶Query changes use DROP+CREATE |
+
+**Legend:**
+- ✅ Fully supported
+- ❌ Not supported (alternative strategy used)  
+- ¹ ALTER DATABASE only supports comment modifications
+- ² Named collections use CREATE OR REPLACE for all modifications
+- ³ Dictionaries use CREATE OR REPLACE for all modifications (ClickHouse limitation)
+- ⁴ Views use CREATE OR REPLACE for modifications
+- ⁵ Views use RENAME TABLE for renames
+- ⁶ Materialized view query changes use DROP+CREATE strategy for reliability
+- ⁷ Materialized views use table operations (ATTACH/DETACH/DROP/RENAME TABLE)
+
+### Migration Strategy Notes
+
+- **Dependencies**: Proper ordering ensures collections → tables → dictionaries → views
+- **Integration Engines**: Tables using Kafka, RabbitMQ, etc. automatically use DROP+CREATE strategy
+- **Cluster Operations**: Full `ON CLUSTER` support, but cluster association cannot be changed after creation
+- **Engine Changes**: Not supported for any object type (requires manual migration)
+- **Smart Rename Detection**: Avoids unnecessary DROP+CREATE when only names change
 
 ## Documentation
 

--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -21,6 +21,9 @@ my-clickhouse-project/
 │   └── schemas/              # Modular schema organization
 │       ├── analytics/
 │       │   ├── schema.sql    # Database definition
+│       │   ├── collections/  # Named collection definitions
+│       │   │   ├── api_configs.sql
+│       │   │   └── kafka_configs.sql
 │       │   ├── tables/       # Table definitions
 │       │   │   ├── events.sql
 │       │   │   ├── users.sql

--- a/docs/how-it-works/migration-generation.md
+++ b/docs/how-it-works/migration-generation.md
@@ -354,8 +354,25 @@ func buildDependencyGraph(schema *Schema) *DependencyGraph {
     for _, db := range schema.Databases {
         graph.Nodes = append(graph.Nodes, db)
         
+        // Named collections are global but tracked per database for organization
+        for _, collection := range db.NamedCollections {
+            graph.Nodes = append(graph.Nodes, collection)
+        }
+        
         for _, table := range db.Tables {
             graph.Nodes = append(graph.Nodes, table)
+            
+            // Table may depend on named collection (integration engines)
+            if table.Engine.UsesNamedCollection() {
+                namedCollection := findNamedCollection(schema, table.Engine.NamedCollection)
+                if namedCollection != nil {
+                    graph.Edges = append(graph.Edges, Dependency{
+                        From: table,
+                        To:   namedCollection,
+                        Type: "named_collection_reference",
+                    })
+                }
+            }
         }
         
         for _, dict := range db.Dictionaries {
@@ -397,20 +414,23 @@ func buildDependencyGraph(schema *Schema) *DependencyGraph {
 
 ```go
 func orderMigrations(changes []Change) []Change {
-    // UP migration order (creation order)
+    // UP migration order (creation order with dependencies)
     order := []string{
         "create_database",
+        "create_named_collection",  // Before tables (integration engines may use them)
         "create_table", 
-        "create_dictionary",
-        "create_view",
-        "alter_table",
+        "create_dictionary",        // After tables (may reference tables)
+        "create_view",             // Last (may reference tables and dictionaries)
         "alter_database",
+        "alter_table",
+        "rename_named_collection",
         "rename_table",
         "rename_dictionary",
-        "drop_view",
-        "drop_dictionary", 
-        "drop_table",
-        "drop_database",
+        "drop_view",               // First to drop (depends on tables/dictionaries)
+        "drop_dictionary",         // Before tables (references them)
+        "drop_table",              // Before named collections (may use them)
+        "drop_named_collection",   // After tables that use them
+        "drop_database",           // Last (contains everything)
     }
     
     // Sort changes by dependency order

--- a/docs/how-it-works/overview.md
+++ b/docs/how-it-works/overview.md
@@ -119,9 +119,10 @@ schema, err := client.GetSchema(ctx)
 The extraction process:
 1. **Connection Management**: Handles various DSN formats and connection options
 2. **System Object Filtering**: Excludes system databases and tables
-3. **Complete Object Support**: Extracts databases, tables, dictionaries, views
-4. **Cluster Awareness**: Injects ON CLUSTER clauses when configured
-5. **DDL Generation**: Produces valid ClickHouse DDL statements
+3. **Complete Object Support**: Extracts databases, tables, named collections, dictionaries, views
+4. **Configuration Filtering**: Excludes `builtin_` prefixed named collections (config-managed)
+5. **Cluster Awareness**: Injects ON CLUSTER clauses when configured
+6. **DDL Generation**: Produces valid ClickHouse DDL statements
 
 #### Supported Connection Types
 ```bash

--- a/docs/user-guide/writing-schemas.md
+++ b/docs/user-guide/writing-schemas.md
@@ -44,6 +44,10 @@ For larger projects, split schemas into logical modules:
 -- Database definitions
 -- housekeeper:import schemas/databases/ecommerce.sql
 
+-- Named collections (connection configs)
+-- housekeeper:import schemas/collections/api_configs.sql
+-- housekeeper:import schemas/collections/kafka_configs.sql
+
 -- Core tables
 -- housekeeper:import schemas/tables/users.sql
 -- housekeeper:import schemas/tables/products.sql
@@ -95,6 +99,105 @@ ENGINE = MySQL('mysql-host:3306', 'database', 'user', 'password');
 -- PostgreSQL integration  
 CREATE DATABASE postgres_data
 ENGINE = PostgreSQL('postgres-host:5432', 'database', 'user', 'password');
+```
+
+## Named Collections
+
+Named collections provide a centralized way to store connection parameters and configuration that can be reused across multiple tables, especially useful for integration engines.
+
+### Basic Named Collections
+
+```sql
+-- API configuration
+CREATE NAMED COLLECTION api_config AS
+    host = 'api.example.com',
+    port = 443,
+    ssl = TRUE,
+    timeout = 30;
+
+-- Database connection
+CREATE NAMED COLLECTION postgres_config AS
+    host = 'postgres-host',
+    port = 5432,
+    user = 'clickhouse_user',
+    password = 'secure_password',
+    database = 'production_db';
+
+-- Kafka configuration  
+CREATE NAMED COLLECTION kafka_cluster AS
+    kafka_broker_list = 'kafka1:9092,kafka2:9092,kafka3:9092',
+    kafka_security_protocol = 'SASL_SSL',
+    kafka_sasl_mechanism = 'PLAIN',
+    kafka_sasl_username = 'clickhouse',
+    kafka_sasl_password = 'secret';
+```
+
+### Using Named Collections with Tables
+
+Named collections are particularly powerful with integration engine tables:
+
+```sql
+-- Kafka table using named collection
+CREATE TABLE events (
+    id UInt64,
+    event_type String,
+    timestamp DateTime,
+    data String
+) ENGINE = Kafka(
+    kafka_cluster,  -- Reference to named collection
+    'events_topic',
+    'analytics_group',
+    'JSONEachRow'
+);
+
+-- PostgreSQL table using named collection
+CREATE TABLE users_staging (
+    id UInt64,
+    email String,
+    name String
+) ENGINE = PostgreSQL(
+    postgres_config,  -- Reference to named collection
+    'users'
+);
+```
+
+### Named Collection Features
+
+- **Centralized Configuration**: Define connection parameters once, use everywhere
+- **Security**: Keeps credentials out of individual table definitions
+- **Cluster Support**: Full `ON CLUSTER` support for distributed deployments
+- **Global Scope**: Named collections are available across all databases
+- **Immutable**: Use `CREATE OR REPLACE` for modifications (no `ALTER` support)
+
+### Configuration vs DDL-Managed Collections
+
+Housekeeper distinguishes between two types of named collections:
+
+1. **DDL-Managed Collections**: Created via `CREATE NAMED COLLECTION` statements
+   - Stored in system.named_collections table
+   - Managed through Housekeeper migrations
+   - Can be created, replaced, and dropped via DDL
+
+2. **Configuration-Managed Collections**: Defined in ClickHouse XML/YAML config files
+   - Also appear in system.named_collections table
+   - Typically prefixed with `builtin_` by convention
+   - Require configuration file changes and server restarts
+   - **Automatically excluded from schema extraction**
+
+> **Note**: Collections with names starting with `builtin_` are filtered out during schema extraction to prevent conflicts between DDL and configuration management approaches. This ensures that configuration-defined collections remain under config management control.
+
+### Cluster-Aware Named Collections
+
+```sql
+-- Named collection for cluster deployment
+CREATE NAMED COLLECTION kafka_cluster 
+ON CLUSTER production
+AS
+    kafka_broker_list = 'kafka1:9092,kafka2:9092',
+    kafka_security_protocol = 'SASL_SSL',
+    kafka_sasl_mechanism = 'PLAIN',
+    kafka_sasl_username = 'clickhouse',
+    kafka_sasl_password = 'secret';
 ```
 
 ## Table Design

--- a/pkg/clickhouse/dictionaries.go
+++ b/pkg/clickhouse/dictionaries.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/pseudomuto/housekeeper/pkg/utils"
 )
 
 // extractDictionaries retrieves all dictionary definitions from the ClickHouse instance.
@@ -69,7 +70,7 @@ func extractDictionaries(ctx context.Context, client *Client) (*parser.SQL, erro
 		}
 
 		// Use SHOW CREATE DICTIONARY to get the DDL
-		fullName := fmt.Sprintf("`%s`.`%s`", database, name)
+		fullName := utils.BacktickQualifiedName(&database, name)
 		showQuery := "SHOW CREATE DICTIONARY " + fullName
 
 		showRows, err := client.conn.Query(ctx, showQuery)

--- a/pkg/clickhouse/named_collections.go
+++ b/pkg/clickhouse/named_collections.go
@@ -1,0 +1,352 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/pseudomuto/housekeeper/pkg/utils"
+)
+
+// extractNamedCollections retrieves all named collection definitions from the ClickHouse instance.
+// This function queries the system.named_collections table to get collection information
+// and returns them as parsed DDL statements.
+//
+// Named collections store connection parameters for external data sources in a centralized
+// and secure way, avoiding credentials in DDL statements.
+//
+// Collections with names starting with 'builtin_' are automatically excluded from extraction
+// as these are typically configuration-managed collections defined in ClickHouse XML/YAML config
+// files rather than DDL-managed collections.
+//
+// Example:
+//
+//	client, err := clickhouse.NewClient(ctx, "localhost:9000")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	defer client.Close()
+//
+//	collections, err := client.GetNamedCollections(ctx)
+//	if err != nil {
+//		log.Fatalf("Failed to extract named collections: %v", err)
+//	}
+//
+//	// Process the parsed named collection statements
+//	for _, stmt := range collections.Statements {
+//		if stmt.CreateNamedCollection != nil {
+//			name := stmt.CreateNamedCollection.Name
+//			fmt.Printf("Named Collection: %s\n", name)
+//		}
+//	}
+//
+// Returns a *parser.SQL containing named collection CREATE statements or an error if extraction fails.
+func extractNamedCollections(ctx context.Context, client *Client) (*parser.SQL, error) {
+	// Note: system.named_collections table structure in ClickHouse:
+	// - name: String - The name of the collection
+	// - key: String - Parameter key
+	// - value: String - Parameter value (may be masked for sensitive data)
+	// - overridable: UInt8 - Whether the parameter can be overridden (1 = true, 0 = false)
+	// - comment: String - Optional comment for the collection (may not exist in older versions)
+
+	if !isNamedCollectionsSupported(ctx, client) {
+		// Named collections not supported in this ClickHouse version
+		return &parser.SQL{Statements: []*parser.Statement{}}, nil
+	}
+
+	query, supported := buildNamedCollectionsQuery(ctx, client)
+	if !supported {
+		// Unsupported table structure
+		return &parser.SQL{Statements: []*parser.Statement{}}, nil
+	}
+
+	collections, err := queryNamedCollectionsData(ctx, client, query)
+	if err != nil {
+		return nil, err
+	}
+
+	addCommentsToCollections(ctx, client, collections)
+
+	return generateNamedCollectionStatements(collections, client.options.Cluster)
+}
+
+// namedCollectionData holds the data for a single named collection
+type namedCollectionData struct {
+	name       string
+	parameters map[string]parameterData
+	comment    string
+}
+
+// parameterData holds the data for a single parameter
+type parameterData struct {
+	value       string
+	overridable bool
+}
+
+// generateCreateNamedCollectionStatement generates a CREATE NAMED COLLECTION statement
+func generateCreateNamedCollectionStatement(collection *namedCollectionData, cluster string) string {
+	var parts []string
+
+	// CREATE NAMED COLLECTION name
+	parts = append(parts, "CREATE NAMED COLLECTION", utils.BacktickIdentifier(collection.name))
+
+	// ON CLUSTER if specified
+	if cluster != "" {
+		parts = append(parts, "ON CLUSTER", utils.BacktickIdentifier(cluster))
+	}
+
+	parts = append(parts, "AS")
+
+	// Build the main statement
+	stmt := strings.Join(parts, " ")
+
+	// Add parameters
+	paramLines := make([]string, 0, len(collection.parameters))
+
+	// Sort parameter names for deterministic output
+	paramNames := make([]string, 0, len(collection.parameters))
+	for key := range collection.parameters {
+		paramNames = append(paramNames, key)
+	}
+	sort.Strings(paramNames)
+
+	// Check if all parameters have the same overridable setting
+	allOverridable, allNotOverridable := true, true
+	for _, param := range collection.parameters {
+		if param.overridable {
+			allNotOverridable = false
+		} else {
+			allOverridable = false
+		}
+	}
+
+	// If all parameters have the same overridable setting, we can use global override
+	useGlobalOverride := allOverridable || allNotOverridable
+
+	for _, key := range paramNames {
+		param := collection.parameters[key]
+
+		// Format the value - add quotes if it's a string value
+		value := param.value
+		if !utils.IsNumericValue(value) && !utils.IsBooleanValue(value) && value != "NULL" {
+			value = fmt.Sprintf("'%s'", escapeString(value))
+		}
+
+		paramLine := fmt.Sprintf("    %s = %s", utils.BacktickIdentifier(key), value)
+
+		// Add per-parameter override only if we're not using global override
+		if !useGlobalOverride {
+			if param.overridable {
+				paramLine += " OVERRIDABLE"
+			} else {
+				paramLine += " NOT OVERRIDABLE"
+			}
+		}
+
+		paramLines = append(paramLines, paramLine)
+	}
+
+	if len(paramLines) > 0 {
+		stmt += "\n" + strings.Join(paramLines, ",\n")
+	}
+
+	// Add global override if applicable
+	if useGlobalOverride && len(collection.parameters) > 0 {
+		if allOverridable {
+			stmt += "\nOVERRIDABLE"
+		} else {
+			stmt += "\nNOT OVERRIDABLE"
+		}
+	}
+
+	// Add comment if present
+	if collection.comment != "" {
+		stmt += fmt.Sprintf("\nCOMMENT '%s'", escapeString(collection.comment))
+	}
+
+	stmt += ";"
+
+	return stmt
+}
+
+// escapeString escapes single quotes in a string
+func escapeString(s string) string {
+	return strings.ReplaceAll(s, "'", "\\'")
+}
+
+// GetNamedCollections retrieves all named collection definitions from the ClickHouse instance
+func (c *Client) GetNamedCollections(ctx context.Context) (*parser.SQL, error) {
+	return extractNamedCollections(ctx, c)
+}
+
+// isNamedCollectionsSupported checks if system.named_collections table exists
+func isNamedCollectionsSupported(ctx context.Context, client *Client) bool {
+	checkQuery := `
+		SELECT count(*) 
+		FROM system.tables 
+		WHERE database = 'system' AND name = 'named_collections'
+	`
+
+	var tableExists uint64
+	err := client.conn.QueryRow(ctx, checkQuery).Scan(&tableExists)
+	return err == nil && tableExists > 0
+}
+
+// buildNamedCollectionsQuery builds the appropriate query based on ClickHouse version
+func buildNamedCollectionsQuery(ctx context.Context, client *Client) (string, bool) {
+	columnsQuery := `
+		SELECT name
+		FROM system.columns
+		WHERE database = 'system' AND table = 'named_collections'
+	`
+
+	columnRows, err := client.conn.Query(ctx, columnsQuery)
+	if err != nil {
+		return "", false
+	}
+	defer columnRows.Close()
+
+	availableColumns := make(map[string]bool)
+	for columnRows.Next() {
+		var columnName string
+		if err := columnRows.Scan(&columnName); err != nil {
+			return "", false
+		}
+		availableColumns[columnName] = true
+	}
+
+	if availableColumns["key"] && availableColumns["value"] {
+		// Newer structure with key-value pairs
+		return `
+			SELECT 
+				name,
+				key,
+				value,
+				overridable
+			FROM system.named_collections
+			WHERE name NOT LIKE 'builtin_%'
+			ORDER BY name, key
+		`, true
+	} else if availableColumns["collection"] {
+		// Older structure where collection is stored as Map(String, String)
+		return `
+			SELECT 
+				name,
+				arrayJoin(mapKeys(collection)) AS key,
+				collection[key] AS value,
+				1 AS overridable
+			FROM system.named_collections
+			WHERE name NOT LIKE 'builtin_%'
+			ORDER BY name, key
+		`, true
+	}
+
+	return "", false
+}
+
+// queryNamedCollectionsData executes the query and collects named collection data
+func queryNamedCollectionsData(ctx context.Context, client *Client, query string) (map[string]*namedCollectionData, error) {
+	rows, err := client.conn.Query(ctx, query)
+	if err != nil {
+		// Named collections might not be available in older ClickHouse versions
+		if strings.Contains(err.Error(), "doesn't exist") {
+			return make(map[string]*namedCollectionData), nil
+		}
+		return nil, errors.Wrap(err, "failed to query named collections")
+	}
+	defer rows.Close()
+
+	collections := make(map[string]*namedCollectionData)
+
+	for rows.Next() {
+		var name, key, value string
+		var overridable uint8
+
+		if err := rows.Scan(&name, &key, &value, &overridable); err != nil {
+			return nil, errors.Wrap(err, "failed to scan named collection row")
+		}
+
+		if _, exists := collections[name]; !exists {
+			collections[name] = &namedCollectionData{
+				name:       name,
+				parameters: make(map[string]parameterData),
+			}
+		}
+
+		collections[name].parameters[key] = parameterData{
+			value:       value,
+			overridable: overridable == 1,
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating named collection rows")
+	}
+
+	return collections, nil
+}
+
+// addCommentsToCollections adds comments to collections if available
+func addCommentsToCollections(ctx context.Context, client *Client, collections map[string]*namedCollectionData) {
+	commentQuery := `
+		SELECT DISTINCT
+			name,
+			comment
+		FROM system.named_collections
+		WHERE comment != '' AND name NOT LIKE 'builtin_%'
+	`
+
+	commentRows, err := client.conn.Query(ctx, commentQuery)
+	if err == nil {
+		defer commentRows.Close()
+		for commentRows.Next() {
+			var name, comment string
+			if err := commentRows.Scan(&name, &comment); err == nil {
+				if collection, exists := collections[name]; exists {
+					collection.comment = comment
+				}
+			}
+		}
+	}
+	// Ignore comment errors as the column might not exist
+}
+
+// generateNamedCollectionStatements generates and parses CREATE NAMED COLLECTION statements
+func generateNamedCollectionStatements(collections map[string]*namedCollectionData, cluster string) (*parser.SQL, error) {
+	statements := make([]string, 0, len(collections))
+
+	// Sort collection names for deterministic output
+	collectionNames := make([]string, 0, len(collections))
+	for name := range collections {
+		collectionNames = append(collectionNames, name)
+	}
+	sort.Strings(collectionNames)
+
+	for _, name := range collectionNames {
+		collection := collections[name]
+		stmt := generateCreateNamedCollectionStatement(collection, cluster)
+
+		// Validate the statement using our parser
+		if err := validateDDLStatement(stmt); err != nil {
+			return nil, errors.Wrapf(err, "generated invalid DDL for named collection %s", name)
+		}
+
+		statements = append(statements, stmt)
+	}
+
+	// Parse all statements
+	fullSQL := strings.Join(statements, "\n\n")
+	if fullSQL == "" {
+		return &parser.SQL{Statements: []*parser.Statement{}}, nil
+	}
+
+	result, err := parser.ParseString(fullSQL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse generated named collection DDL")
+	}
+
+	return result, nil
+}

--- a/pkg/clickhouse/named_collections_test.go
+++ b/pkg/clickhouse/named_collections_test.go
@@ -1,0 +1,165 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildNamedCollectionsQuery(t *testing.T) {
+	tests := []struct {
+		name              string
+		availableColumns  map[string]bool
+		expectedQuery     string
+		expectedSupported bool
+	}{
+		{
+			name: "newer structure with key-value pairs filters builtin collections",
+			availableColumns: map[string]bool{
+				"name":        true,
+				"key":         true,
+				"value":       true,
+				"overridable": true,
+			},
+			expectedQuery: `
+			SELECT 
+				name,
+				key,
+				value,
+				overridable
+			FROM system.named_collections
+			WHERE name NOT LIKE 'builtin_%'
+			ORDER BY name, key
+		`,
+			expectedSupported: true,
+		},
+		{
+			name: "older structure with Map filters builtin collections",
+			availableColumns: map[string]bool{
+				"name":       true,
+				"collection": true,
+			},
+			expectedQuery: `
+			SELECT 
+				name,
+				arrayJoin(mapKeys(collection)) AS key,
+				collection[key] AS value,
+				1 AS overridable
+			FROM system.named_collections
+			WHERE name NOT LIKE 'builtin_%'
+			ORDER BY name, key
+		`,
+			expectedSupported: true,
+		},
+		{
+			name: "unsupported structure returns false",
+			availableColumns: map[string]bool{
+				"name": true,
+			},
+			expectedQuery:     "",
+			expectedSupported: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the function logic without requiring a real client
+			query, supported := mockBuildNamedCollectionsQuery(tt.availableColumns)
+
+			require.Equal(t, tt.expectedSupported, supported)
+
+			if supported {
+				// Normalize whitespace for comparison
+				require.Contains(t, query, "WHERE name NOT LIKE 'builtin_%'",
+					"Query should filter out collections starting with 'builtin_'")
+				require.Contains(t, query, "FROM system.named_collections")
+				require.Contains(t, query, "ORDER BY name, key")
+			} else {
+				require.Empty(t, query)
+			}
+		})
+	}
+}
+
+// mockBuildNamedCollectionsQuery replicates the logic from buildNamedCollectionsQuery
+// for testing without requiring a real ClickHouse connection
+func mockBuildNamedCollectionsQuery(availableColumns map[string]bool) (string, bool) {
+	if availableColumns["key"] && availableColumns["value"] {
+		// Newer structure with key-value pairs
+		return `
+			SELECT 
+				name,
+				key,
+				value,
+				overridable
+			FROM system.named_collections
+			WHERE name NOT LIKE 'builtin_%'
+			ORDER BY name, key
+		`, true
+	} else if availableColumns["collection"] {
+		// Older structure where collection is stored as Map(String, String)
+		return `
+			SELECT 
+				name,
+				arrayJoin(mapKeys(collection)) AS key,
+				collection[key] AS value,
+				1 AS overridable
+			FROM system.named_collections
+			WHERE name NOT LIKE 'builtin_%'
+			ORDER BY name, key
+		`, true
+	}
+
+	return "", false
+}
+
+func TestFilterBuiltinCollections(t *testing.T) {
+	tests := []struct {
+		name           string
+		collectionName string
+		shouldFilter   bool
+	}{
+		{
+			name:           "builtin collection with builtin_ prefix should be filtered",
+			collectionName: "builtin_kafka",
+			shouldFilter:   true,
+		},
+		{
+			name:           "builtin collection with BUILTIN_ prefix should be filtered",
+			collectionName: "BUILTIN_mysql",
+			shouldFilter:   false, // SQL LIKE is case-sensitive
+		},
+		{
+			name:           "user collection without builtin_ prefix should not be filtered",
+			collectionName: "my_kafka_config",
+			shouldFilter:   false,
+		},
+		{
+			name:           "user collection containing builtin but not as prefix should not be filtered",
+			collectionName: "kafka_builtin_config",
+			shouldFilter:   false,
+		},
+		{
+			name:           "empty collection name should not be filtered",
+			collectionName: "",
+			shouldFilter:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the LIKE pattern matching logic
+			filtered := isBuiltinCollection(tt.collectionName)
+			if tt.shouldFilter {
+				require.True(t, filtered, "Collection '%s' should be filtered", tt.collectionName)
+			} else {
+				require.False(t, filtered, "Collection '%s' should not be filtered", tt.collectionName)
+			}
+		})
+	}
+}
+
+// isBuiltinCollection simulates the SQL LIKE 'builtin_%' pattern matching
+func isBuiltinCollection(name string) bool {
+	return len(name) >= 8 && name[:8] == "builtin_"
+}

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 
 	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/pseudomuto/housekeeper/pkg/utils"
 )
 
 type (
@@ -268,6 +269,12 @@ func (f *Formatter) statement(w io.Writer, stmt *parser.Statement) error {
 		return f.renameTable(w, stmt.RenameTable)
 	case stmt.CreateDictionary != nil:
 		return f.createDictionary(w, stmt.CreateDictionary)
+	case stmt.CreateNamedCollection != nil:
+		return f.createNamedCollection(w, stmt.CreateNamedCollection)
+	case stmt.AlterNamedCollection != nil:
+		return f.alterNamedCollection(w, stmt.AlterNamedCollection)
+	case stmt.DropNamedCollection != nil:
+		return f.dropNamedCollection(w, stmt.DropNamedCollection)
 	case stmt.AttachDictionary != nil:
 		return f.attachDictionary(w, stmt.AttachDictionary)
 	case stmt.DetachDictionary != nil:
@@ -300,23 +307,16 @@ func (f *Formatter) keyword(kw string) string {
 }
 
 // indent returns the specified number of indent levels as spaces
-func (f *Formatter) indent(level int) string {
+func (f *Formatter) indent(level int) string { // nolint: unparam
 	return strings.Repeat(" ", level*f.options.IndentSize)
 }
 
 // qualifiedName formats a database-qualified name with backticks
 func (f *Formatter) qualifiedName(database *string, name string) string {
-	if database != nil && *database != "" {
-		return f.identifier(*database) + "." + f.identifier(name)
-	}
-	return f.identifier(name)
+	return utils.BacktickQualifiedName(database, name)
 }
 
 // identifier formats a single identifier with backticks
 func (f *Formatter) identifier(name string) string {
-	// Don't double-backtick identifiers that are already backticked
-	if len(name) >= 2 && name[0] == '`' && name[len(name)-1] == '`' {
-		return name
-	}
-	return "`" + name + "`"
+	return utils.BacktickIdentifier(name)
 }

--- a/pkg/format/named_collection.go
+++ b/pkg/format/named_collection.go
@@ -1,0 +1,224 @@
+package format
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+)
+
+// CreateNamedCollection formats a CREATE NAMED COLLECTION statement
+func (f *Formatter) createNamedCollection(w io.Writer, stmt *parser.CreateNamedCollectionStmt) error {
+	var lines []string
+
+	// Build the header line
+	var headerParts []string
+	headerParts = append(headerParts, f.keyword("CREATE"))
+
+	if stmt.OrReplace {
+		headerParts = append(headerParts, f.keyword("OR REPLACE"))
+	}
+
+	headerParts = append(headerParts, f.keyword("NAMED COLLECTION"))
+
+	if stmt.IfNotExists != nil {
+		headerParts = append(headerParts, f.keyword("IF NOT EXISTS"))
+	}
+
+	headerParts = append(headerParts, f.identifier(stmt.Name))
+
+	if stmt.OnCluster != nil {
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+	}
+
+	headerParts = append(headerParts, f.keyword("AS"))
+
+	lines = append(lines, strings.Join(headerParts, " "))
+
+	// Format parameters
+	f.formatCreateNamedCollectionParameters(&lines, stmt)
+
+	// Add global override if present on its own line
+	if stmt.GlobalOverride != nil {
+		if stmt.GlobalOverride.NotOverridable {
+			lines = append(lines, f.keyword("NOT OVERRIDABLE"))
+		} else if stmt.GlobalOverride.Overridable {
+			lines = append(lines, f.keyword("OVERRIDABLE"))
+		}
+	}
+
+	// Add comment if present
+	if stmt.Comment != nil {
+		lines = append(lines, f.keyword("COMMENT")+" "+*stmt.Comment)
+	}
+
+	// Join lines and add semicolon
+	result := strings.Join(lines, "\n") + ";"
+	_, err := w.Write([]byte(result))
+	return err
+}
+
+// AlterNamedCollection formats an ALTER NAMED COLLECTION statement
+func (f *Formatter) alterNamedCollection(w io.Writer, stmt *parser.AlterNamedCollectionStmt) error {
+	var lines []string
+
+	// Build the header line
+	var headerParts []string
+	headerParts = append(headerParts, f.keyword("ALTER"))
+	headerParts = append(headerParts, f.keyword("NAMED COLLECTION"))
+
+	if stmt.IfExists != nil {
+		headerParts = append(headerParts, f.keyword("IF EXISTS"))
+	}
+
+	headerParts = append(headerParts, f.identifier(stmt.Name))
+
+	if stmt.OnCluster != nil {
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+	}
+
+	lines = append(lines, strings.Join(headerParts, " "))
+
+	// Format operations
+	if stmt.Operations != nil {
+		f.formatAlterNamedCollectionOperations(&lines, stmt.Operations)
+	}
+
+	// Join lines and add semicolon
+	result := strings.Join(lines, "\n") + ";"
+	_, err := w.Write([]byte(result))
+	return err
+}
+
+// DropNamedCollection formats a DROP NAMED COLLECTION statement
+func (f *Formatter) dropNamedCollection(w io.Writer, stmt *parser.DropNamedCollectionStmt) error {
+	var headerParts []string
+	headerParts = append(headerParts, f.keyword("DROP"))
+	headerParts = append(headerParts, f.keyword("NAMED COLLECTION"))
+
+	if stmt.IfExists != nil {
+		headerParts = append(headerParts, f.keyword("IF EXISTS"))
+	}
+
+	headerParts = append(headerParts, f.identifier(stmt.Name))
+
+	if stmt.OnCluster != nil {
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+	}
+
+	line := strings.Join(headerParts, " ") + ";"
+	_, err := w.Write([]byte(line))
+	return err
+}
+
+// formatCreateNamedCollectionParameters formats the parameters section of a CREATE NAMED COLLECTION statement
+func (f *Formatter) formatCreateNamedCollectionParameters(lines *[]string, stmt *parser.CreateNamedCollectionStmt) {
+	if len(stmt.Parameters) == 0 {
+		return
+	}
+
+	for i, param := range stmt.Parameters {
+		paramLine := f.formatSingleParameter(param, stmt.GlobalOverride == nil)
+		if f.shouldAddComma(i, len(stmt.Parameters), stmt.GlobalOverride != nil) {
+			paramLine += ","
+		}
+		*lines = append(*lines, paramLine)
+	}
+}
+
+// formatAlterNamedCollectionOperations formats the operations section of an ALTER NAMED COLLECTION statement
+func (f *Formatter) formatAlterNamedCollectionOperations(lines *[]string, ops *parser.AlterNamedCollectionOperations) {
+	if len(ops.SetParams) > 0 {
+		f.addSetOperation(lines, ops)
+	} else if len(ops.DeleteParams) > 0 {
+		f.addDeleteOperation(lines, ops.DeleteParams)
+	}
+}
+
+// formatSingleParameter formats a single parameter with its override clause
+func (f *Formatter) formatSingleParameter(param *parser.NamedCollectionParameter, allowOverride bool) string {
+	paramLine := f.indent(1) + f.identifier(param.Key) + " = " + f.formatNamedCollectionValue(param.Value)
+
+	if allowOverride && param.Override != nil {
+		if param.Override.NotOverridable {
+			paramLine += " " + f.keyword("NOT OVERRIDABLE")
+		} else if param.Override.Overridable {
+			paramLine += " " + f.keyword("OVERRIDABLE")
+		}
+	}
+
+	return paramLine
+}
+
+// shouldAddComma determines if a comma should be added after a parameter
+func (f *Formatter) shouldAddComma(index, total int, hasGlobalOverride bool) bool {
+	return index < total-1 || hasGlobalOverride
+}
+
+// addSetOperation adds a SET operation to the lines
+func (f *Formatter) addSetOperation(lines *[]string, ops *parser.AlterNamedCollectionOperations) {
+	setLine := f.indent(1) + f.keyword("SET") + " "
+
+	paramParts := make([]string, 0, len(ops.SetParams))
+	for _, param := range ops.SetParams {
+		paramLine := f.identifier(param.Key) + " = " + f.formatNamedCollectionValue(param.Value)
+
+		if param.Override != nil {
+			if param.Override.NotOverridable {
+				paramLine += " " + f.keyword("NOT OVERRIDABLE")
+			} else if param.Override.Overridable {
+				paramLine += " " + f.keyword("OVERRIDABLE")
+			}
+		}
+
+		paramParts = append(paramParts, paramLine)
+	}
+
+	setLine += strings.Join(paramParts, ", ")
+
+	if len(ops.DeleteParams) > 0 {
+		setLine += "\n" + f.indent(1) + f.keyword("DELETE") + " " + f.formatDeleteKeys(ops.DeleteParams)
+	}
+
+	*lines = append(*lines, setLine)
+}
+
+// addDeleteOperation adds a DELETE-only operation to the lines
+func (f *Formatter) addDeleteOperation(lines *[]string, deleteParams []*string) {
+	deleteKeys := f.formatDeleteKeys(deleteParams)
+	*lines = append(*lines, f.indent(1)+f.keyword("DELETE")+" "+deleteKeys)
+}
+
+// formatDeleteKeys formats a list of delete parameter keys
+func (f *Formatter) formatDeleteKeys(deleteParams []*string) string {
+	deleteKeys := make([]string, len(deleteParams))
+	for i, key := range deleteParams {
+		deleteKeys[i] = f.identifier(*key)
+	}
+	return strings.Join(deleteKeys, ", ")
+}
+
+// formatNamedCollectionValue formats a named collection parameter value
+func (f *Formatter) formatNamedCollectionValue(value *parser.NamedCollectionValue) string {
+	if value.String != nil {
+		return *value.String
+	}
+	if value.Number != nil {
+		// Format the number appropriately
+		if float64(int64(*value.Number)) == *value.Number {
+			// It's an integer
+			return strconv.FormatInt(int64(*value.Number), 10)
+		}
+		// It's a float
+		return fmt.Sprintf("%g", *value.Number)
+	}
+	if value.Bool != nil {
+		return *value.Bool
+	}
+	if value.Null != nil {
+		return "NULL"
+	}
+	return ""
+}

--- a/pkg/format/testdata/named_collection_operations.in.sql
+++ b/pkg/format/testdata/named_collection_operations.in.sql
@@ -1,0 +1,23 @@
+-- Named collection operations
+CREATE NAMED COLLECTION my_s3_collection AS
+    access_key_id = 'AKIAIOSFODNN7EXAMPLE',
+    secret_access_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    endpoint = 'https://s3.amazonaws.com/',
+    region = 'us-east-1'
+NOT OVERRIDABLE;
+
+CREATE OR REPLACE NAMED COLLECTION IF NOT EXISTS kafka_config ON CLUSTER production AS
+    kafka_broker_list = 'localhost:9092',
+    kafka_topic_list = 'events',
+    kafka_group_name = 'clickhouse',
+    kafka_format = 'JSONEachRow',
+    kafka_max_block_size = 1048576
+OVERRIDABLE
+COMMENT 'Kafka configuration for events';
+
+ALTER NAMED COLLECTION kafka_config
+    SET kafka_topic_list = 'events,logs' OVERRIDABLE,
+        kafka_max_block_size = 2097152 NOT OVERRIDABLE
+    DELETE kafka_skip_broken_messages;
+
+DROP NAMED COLLECTION IF EXISTS old_s3_config ON CLUSTER production;

--- a/pkg/format/testdata/named_collection_operations.sql
+++ b/pkg/format/testdata/named_collection_operations.sql
@@ -1,0 +1,18 @@
+CREATE NAMED COLLECTION `my_s3_collection` AS
+    `access_key_id` = 'AKIAIOSFODNN7EXAMPLE',
+    `secret_access_key` = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    `endpoint` = 'https://s3.amazonaws.com/',
+    `region` = 'us-east-1' NOT OVERRIDABLE;
+
+CREATE OR REPLACE NAMED COLLECTION IF NOT EXISTS `kafka_config` ON CLUSTER `production` AS
+    `kafka_broker_list` = 'localhost:9092',
+    `kafka_topic_list` = 'events',
+    `kafka_group_name` = 'clickhouse',
+    `kafka_format` = 'JSONEachRow',
+    `kafka_max_block_size` = 1048576 OVERRIDABLE
+COMMENT 'Kafka configuration for events';
+
+ALTER NAMED COLLECTION `kafka_config`
+    SET `kafka_topic_list` = 'events,logs' OVERRIDABLE, `kafka_max_block_size` = 2097152 NOT OVERRIDABLE;
+
+DROP NAMED COLLECTION IF EXISTS `old_s3_config` ON CLUSTER `production`;

--- a/pkg/parser/named_collection.go
+++ b/pkg/parser/named_collection.go
@@ -1,0 +1,126 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Named collection-related grammar types for ClickHouse NAMED COLLECTION statements
+
+type (
+	// CreateNamedCollectionStmt represents CREATE [OR REPLACE] NAMED COLLECTION statements.
+	// ClickHouse syntax:
+	//   CREATE [OR REPLACE] NAMED COLLECTION [IF NOT EXISTS] collection_name [ON CLUSTER cluster] AS
+	//     key1 = value1 [OVERRIDABLE | NOT OVERRIDABLE],
+	//     key2 = value2 [OVERRIDABLE | NOT OVERRIDABLE],
+	//     ...
+	//   [COMMENT 'comment']
+	CreateNamedCollectionStmt struct {
+		Create         string                      `parser:"'CREATE'"`
+		OrReplace      bool                        `parser:"@('OR' 'REPLACE')?"`
+		Named          string                      `parser:"'NAMED'"`
+		Collection     string                      `parser:"'COLLECTION'"`
+		IfNotExists    *string                     `parser:"(@'IF' 'NOT' 'EXISTS')?"`
+		Name           string                      `parser:"@(Ident | BacktickIdent)"`
+		OnCluster      *string                     `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		As             string                      `parser:"'AS'"`
+		Parameters     []*NamedCollectionParameter `parser:"@@*"`
+		GlobalOverride *NamedCollectionOverride    `parser:"@@?"`
+		Comment        *string                     `parser:"('COMMENT' @String)? ';'"`
+	}
+
+	// AlterNamedCollectionStmt represents ALTER NAMED COLLECTION statements.
+	// ClickHouse syntax:
+	//   ALTER NAMED COLLECTION [IF EXISTS] collection_name [ON CLUSTER cluster]
+	//     [SET key1 = value1 [OVERRIDABLE | NOT OVERRIDABLE] [, ...]]
+	//     [DELETE key1, key2, ...]
+	//     [SET key3 = value3 [OVERRIDABLE | NOT OVERRIDABLE] [DELETE key4]]
+	AlterNamedCollectionStmt struct {
+		Alter      string                          `parser:"'ALTER'"`
+		Named      string                          `parser:"'NAMED'"`
+		Collection string                          `parser:"'COLLECTION'"`
+		IfExists   *string                         `parser:"(@'IF' 'EXISTS')?"`
+		Name       string                          `parser:"@(Ident | BacktickIdent)"`
+		OnCluster  *string                         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Operations *AlterNamedCollectionOperations `parser:"@@? ';'"`
+	}
+
+	// AlterNamedCollectionOperations represents all operations in an ALTER NAMED COLLECTION statement
+	AlterNamedCollectionOperations struct {
+		SetParams    []*NamedCollectionSetParameter `parser:"('SET' @@ (',' @@)*)?"`
+		DeleteParams []*string                      `parser:"('DELETE' @(Ident | BacktickIdent) (',' @(Ident | BacktickIdent))*)?"`
+	}
+
+	// NamedCollectionSetParameter represents a single SET parameter in an ALTER NAMED COLLECTION
+	NamedCollectionSetParameter struct {
+		Key      string                   `parser:"@(Ident | BacktickIdent) '='"`
+		Value    *NamedCollectionValue    `parser:"@@"`
+		Override *NamedCollectionOverride `parser:"@@?"`
+	}
+
+	// DropNamedCollectionStmt represents DROP NAMED COLLECTION statements.
+	// ClickHouse syntax:
+	//   DROP NAMED COLLECTION [IF EXISTS] collection_name [ON CLUSTER cluster]
+	DropNamedCollectionStmt struct {
+		Drop       string  `parser:"'DROP'"`
+		Named      string  `parser:"'NAMED'"`
+		Collection string  `parser:"'COLLECTION'"`
+		IfExists   *string `parser:"(@'IF' 'EXISTS')?"`
+		Name       string  `parser:"@(Ident | BacktickIdent)"`
+		OnCluster  *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Semicolon  string  `parser:"';'"`
+	}
+
+	// NamedCollectionParameter represents a key-value pair in a CREATE NAMED COLLECTION statement
+	NamedCollectionParameter struct {
+		Key      string                   `parser:"@(Ident | BacktickIdent) '='"`
+		Value    *NamedCollectionValue    `parser:"@@"`
+		Override *NamedCollectionOverride `parser:"@@?"`
+		Comma    *string                  `parser:"@','?"`
+	}
+
+	// NamedCollectionValue represents the value part of a named collection parameter
+	NamedCollectionValue struct {
+		String *string  `parser:"@String"`
+		Number *float64 `parser:"| @Number"`
+		Bool   *string  `parser:"| @('TRUE' | 'FALSE')"`
+		Null   *string  `parser:"| @'NULL'"`
+	}
+
+	// NamedCollectionOverride represents the OVERRIDABLE or NOT OVERRIDABLE clause
+	NamedCollectionOverride struct {
+		NotOverridable bool `parser:"@('NOT' 'OVERRIDABLE')"`
+		Overridable    bool `parser:"| @'OVERRIDABLE'"`
+	}
+)
+
+// IsOverridable returns true if the override is explicitly overridable
+func (o *NamedCollectionOverride) IsOverridable() bool {
+	if o == nil {
+		return true // default is overridable if not specified
+	}
+	return o.Overridable
+}
+
+// GetValue returns the string representation of the value
+func (v *NamedCollectionValue) GetValue() string {
+	if v.String != nil {
+		return *v.String
+	}
+	if v.Number != nil {
+		// Format the number appropriately
+		if float64(int64(*v.Number)) == *v.Number {
+			// It's an integer
+			return strconv.FormatInt(int64(*v.Number), 10)
+		}
+		// It's a float
+		return fmt.Sprintf("%g", *v.Number)
+	}
+	if v.Bool != nil {
+		return *v.Bool
+	}
+	if v.Null != nil {
+		return "NULL"
+	}
+	return ""
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -110,28 +110,31 @@ type (
 
 	// Statement represents any DDL or DML statement
 	Statement struct {
-		CreateDatabase   *CreateDatabaseStmt      `parser:"@@"`
-		AlterDatabase    *AlterDatabaseStmt       `parser:"| @@"`
-		AttachDatabase   *AttachDatabaseStmt      `parser:"| @@"`
-		DetachDatabase   *DetachDatabaseStmt      `parser:"| @@"`
-		DropDatabase     *DropDatabaseStmt        `parser:"| @@"`
-		RenameDatabase   *RenameDatabaseStmt      `parser:"| @@"`
-		CreateTable      *CreateTableStmt         `parser:"| @@"`
-		AlterTable       *AlterTableStmt          `parser:"| @@"`
-		CreateDictionary *CreateDictionaryStmt    `parser:"| @@"`
-		CreateView       *CreateViewStmt          `parser:"| @@"`
-		AttachView       *AttachViewStmt          `parser:"| @@"`
-		AttachDictionary *AttachDictionaryStmt    `parser:"| @@"`
-		DetachView       *DetachViewStmt          `parser:"| @@"`
-		DetachDictionary *DetachDictionaryStmt    `parser:"| @@"`
-		DropView         *DropViewStmt            `parser:"| @@"`
-		DropDictionary   *DropDictionaryStmt      `parser:"| @@"`
-		AttachTable      *AttachTableStmt         `parser:"| @@"`
-		DetachTable      *DetachTableStmt         `parser:"| @@"`
-		DropTable        *DropTableStmt           `parser:"| @@"`
-		RenameTable      *RenameTableStmt         `parser:"| @@"`
-		RenameDictionary *RenameDictionaryStmt    `parser:"| @@"`
-		SelectStatement  *TopLevelSelectStatement `parser:"| @@"`
+		CreateDatabase        *CreateDatabaseStmt        `parser:"@@"`
+		AlterDatabase         *AlterDatabaseStmt         `parser:"| @@"`
+		AttachDatabase        *AttachDatabaseStmt        `parser:"| @@"`
+		DetachDatabase        *DetachDatabaseStmt        `parser:"| @@"`
+		DropDatabase          *DropDatabaseStmt          `parser:"| @@"`
+		RenameDatabase        *RenameDatabaseStmt        `parser:"| @@"`
+		CreateTable           *CreateTableStmt           `parser:"| @@"`
+		AlterTable            *AlterTableStmt            `parser:"| @@"`
+		CreateDictionary      *CreateDictionaryStmt      `parser:"| @@"`
+		CreateView            *CreateViewStmt            `parser:"| @@"`
+		CreateNamedCollection *CreateNamedCollectionStmt `parser:"| @@"`
+		AlterNamedCollection  *AlterNamedCollectionStmt  `parser:"| @@"`
+		AttachView            *AttachViewStmt            `parser:"| @@"`
+		AttachDictionary      *AttachDictionaryStmt      `parser:"| @@"`
+		DetachView            *DetachViewStmt            `parser:"| @@"`
+		DetachDictionary      *DetachDictionaryStmt      `parser:"| @@"`
+		DropView              *DropViewStmt              `parser:"| @@"`
+		DropDictionary        *DropDictionaryStmt        `parser:"| @@"`
+		DropNamedCollection   *DropNamedCollectionStmt   `parser:"| @@"`
+		AttachTable           *AttachTableStmt           `parser:"| @@"`
+		DetachTable           *DetachTableStmt           `parser:"| @@"`
+		DropTable             *DropTableStmt             `parser:"| @@"`
+		RenameTable           *RenameTableStmt           `parser:"| @@"`
+		RenameDictionary      *RenameDictionaryStmt      `parser:"| @@"`
+		SelectStatement       *TopLevelSelectStatement   `parser:"| @@"`
 	}
 )
 

--- a/pkg/parser/testdata/named_collection_alter.sql
+++ b/pkg/parser/testdata/named_collection_alter.sql
@@ -1,0 +1,4 @@
+ALTER NAMED COLLECTION kafka_config
+    SET kafka_topic_list = 'events,logs' OVERRIDABLE,
+        kafka_max_block_size = 2097152 NOT OVERRIDABLE
+    DELETE kafka_skip_broken_messages;

--- a/pkg/parser/testdata/named_collection_alter.yaml
+++ b/pkg/parser/testdata/named_collection_alter.yaml
@@ -1,0 +1,3 @@
+named_collections:
+    - name: kafka_config
+      operation: ALTER

--- a/pkg/parser/testdata/named_collection_create.sql
+++ b/pkg/parser/testdata/named_collection_create.sql
@@ -1,0 +1,6 @@
+CREATE NAMED COLLECTION my_s3_collection AS
+    access_key_id = 'AKIAIOSFODNN7EXAMPLE',
+    secret_access_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    endpoint = 'https://s3.amazonaws.com/',
+    region = 'us-east-1'
+NOT OVERRIDABLE;

--- a/pkg/parser/testdata/named_collection_create.yaml
+++ b/pkg/parser/testdata/named_collection_create.yaml
@@ -1,0 +1,8 @@
+named_collections:
+    - name: my_s3_collection
+      operation: CREATE
+      parameters:
+        access_key_id: '''AKIAIOSFODNN7EXAMPLE'''
+        endpoint: '''https://s3.amazonaws.com/'''
+        region: '''us-east-1'''
+        secret_access_key: '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'''

--- a/pkg/parser/testdata/named_collection_create_kafka.sql
+++ b/pkg/parser/testdata/named_collection_create_kafka.sql
@@ -1,0 +1,8 @@
+CREATE NAMED COLLECTION kafka_config AS
+    kafka_broker_list = 'localhost:9092',
+    kafka_topic_list = 'events',
+    kafka_group_name = 'clickhouse',
+    kafka_format = 'JSONEachRow',
+    kafka_max_block_size = 1048576,
+    kafka_skip_broken_messages = 1
+OVERRIDABLE;

--- a/pkg/parser/testdata/named_collection_create_kafka.yaml
+++ b/pkg/parser/testdata/named_collection_create_kafka.yaml
@@ -1,0 +1,10 @@
+named_collections:
+    - name: kafka_config
+      operation: CREATE
+      parameters:
+        kafka_broker_list: '''localhost:9092'''
+        kafka_format: '''JSONEachRow'''
+        kafka_group_name: '''clickhouse'''
+        kafka_max_block_size: "1048576"
+        kafka_skip_broken_messages: "1"
+        kafka_topic_list: '''events'''

--- a/pkg/parser/testdata/named_collection_drop.sql
+++ b/pkg/parser/testdata/named_collection_drop.sql
@@ -1,0 +1,1 @@
+DROP NAMED COLLECTION IF EXISTS old_s3_config;

--- a/pkg/parser/testdata/named_collection_drop.yaml
+++ b/pkg/parser/testdata/named_collection_drop.yaml
@@ -1,0 +1,4 @@
+named_collections:
+    - name: old_s3_config
+      operation: DROP
+      if_exists: true

--- a/pkg/project/embed/main.sql
+++ b/pkg/project/embed/main.sql
@@ -10,16 +10,16 @@
 -- db/main.sql (this file)
 --   -- housekeeper:import schemas/[DATABASE]/db.sql
 -- db/migrations/
---   [ENV]/
---     [TIMESTAMP].sql (auto-generated migrations)
---     housekeeper.sum (checksums for migrations)
+--   [TIMESTAMP].sql (auto-generated migrations)
+--   housekeeper.sum (checksums for migrations)
 -- db/schemas/
 --   [DATABASE]
 --     schema.sql
+--       -- housekeeper:import collections/[COLLECTION].sql
 --       -- housekeeper:import tables/[TABLE].sql
+--     collections/
+--       [COLLECTION].sql
 --     dictionaries/
 --     tables/
 --       [TABLE].sql
 --     views/
-
-

--- a/pkg/project/image_test.go
+++ b/pkg/project/image_test.go
@@ -72,6 +72,35 @@ func TestGenerateImage(t *testing.T) {
 			},
 		},
 		{
+			name: "named collections are organized properly",
+			sql: `
+				CREATE DATABASE analytics ENGINE = Atomic;
+				
+				CREATE NAMED COLLECTION kafka_config AS
+					host = 'localhost',
+					port = 9092;
+					
+				CREATE TABLE analytics.events (
+					id UInt64,
+					message String
+				) ENGINE = MergeTree() ORDER BY id;
+			`,
+			fileTests: []fileTest{
+				{"db/main.sql", "-- housekeeper:import schemas/analytics/schema.sql"},
+				{"db/main.sql", "-- housekeeper:import schemas/default/schema.sql"},
+				{"db/schemas/analytics/schema.sql", "CREATE DATABASE `analytics` ENGINE = Atomic"},
+				{"db/schemas/analytics/schema.sql", "-- housekeeper:import tables/events.sql"},
+				{"db/schemas/default/schema.sql", "-- Named Collections"},
+				{"db/schemas/default/schema.sql", "-- housekeeper:import collections/kafka_config.sql"},
+				{"db/schemas/analytics/tables/events.sql", "CREATE TABLE `analytics`.`events`"},
+				{"db/schemas/analytics/tables/events.sql", "`id`      UInt64"},
+				{"db/schemas/analytics/tables/events.sql", "`message` String"},
+				{"db/schemas/default/collections/kafka_config.sql", "CREATE NAMED COLLECTION `kafka_config`"},
+				{"db/schemas/default/collections/kafka_config.sql", "`host` = 'localhost'"},
+				{"db/schemas/default/collections/kafka_config.sql", "`port` = 9092"},
+			},
+		},
+		{
 			name: "table without explicit database uses default",
 			sql: `
 				CREATE TABLE events (id UInt64) ENGINE = MergeTree() ORDER BY id;
@@ -125,6 +154,7 @@ type fileTest struct {
 func TestGenerateImage_FileStructure(t *testing.T) {
 	sql := `
 		CREATE DATABASE analytics ENGINE = Atomic;
+		CREATE NAMED COLLECTION api_config AS host = 'api.example.com', port = 8080;
 		CREATE TABLE analytics.events (id UInt64) ENGINE = MergeTree() ORDER BY id;
 		CREATE DICTIONARY analytics.lookup (id UInt64) PRIMARY KEY id SOURCE(HTTP(url 'http://example.com')) LAYOUT(HASHED()) LIFETIME(3600);
 		CREATE VIEW analytics.summary AS SELECT count() FROM events;
@@ -159,6 +189,8 @@ func TestGenerateImage_FileStructure(t *testing.T) {
 	expectedFiles := []string{
 		"db/main.sql",
 		"db/schemas/analytics/schema.sql",
+		"db/schemas/default/schema.sql",
+		"db/schemas/default/collections/api_config.sql",
 		"db/schemas/analytics/tables/events.sql",
 		"db/schemas/analytics/dictionaries/lookup.sql",
 		"db/schemas/analytics/views/summary.sql",

--- a/pkg/schema/named_collection.go
+++ b/pkg/schema/named_collection.go
@@ -1,0 +1,411 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/pseudomuto/housekeeper/pkg/utils"
+)
+
+const (
+	// NamedCollectionDiffCreate indicates a named collection needs to be created
+	NamedCollectionDiffCreate NamedCollectionDiffType = "CREATE"
+	// NamedCollectionDiffDrop indicates a named collection needs to be dropped
+	NamedCollectionDiffDrop NamedCollectionDiffType = "DROP"
+	// NamedCollectionDiffAlter indicates a named collection needs to be altered
+	NamedCollectionDiffAlter NamedCollectionDiffType = "ALTER"
+	// NamedCollectionDiffReplace indicates a named collection needs to be replaced
+	NamedCollectionDiffReplace NamedCollectionDiffType = "REPLACE"
+	// NamedCollectionDiffRename indicates a named collection needs to be renamed
+	NamedCollectionDiffRename NamedCollectionDiffType = "RENAME"
+)
+
+type (
+	// NamedCollectionDiff represents a difference between current and target named collection states.
+	// It contains all information needed to generate migration SQL statements for
+	// named collection operations including CREATE, DROP, ALTER, REPLACE, and RENAME.
+	NamedCollectionDiff struct {
+		Type              NamedCollectionDiffType // Type of operation (CREATE, DROP, ALTER, REPLACE, RENAME)
+		CollectionName    string                  // Name of the named collection
+		Description       string                  // Human-readable description of the change
+		UpSQL             string                  // SQL to apply the change (forward migration)
+		DownSQL           string                  // SQL to rollback the change (reverse migration)
+		Current           *NamedCollectionInfo    // Current state (nil if collection doesn't exist)
+		Target            *NamedCollectionInfo    // Target state (nil if collection should be dropped)
+		NewCollectionName string                  // For rename operations - the new name
+	}
+
+	// NamedCollectionDiffType represents the type of named collection difference
+	NamedCollectionDiffType string
+
+	// NamedCollectionInfo represents parsed named collection information extracted from DDL statements.
+	// This structure contains all the properties needed for named collection comparison and
+	// migration generation, including the full parsed statement for deep comparison.
+	NamedCollectionInfo struct {
+		Name        string                            // Collection name
+		Cluster     string                            // Cluster name if specified (empty if not clustered)
+		Comment     string                            // Collection comment (without quotes)
+		Parameters  map[string]string                 // Key-value parameters
+		Overridable *bool                             // Global override setting (nil if not specified)
+		Statement   *parser.CreateNamedCollectionStmt // Full parsed CREATE NAMED COLLECTION statement
+	}
+)
+
+// extractNamedCollectionInfo extracts NamedCollectionInfo from a CREATE NAMED COLLECTION statement
+func extractNamedCollectionInfo(stmt *parser.CreateNamedCollectionStmt) *NamedCollectionInfo {
+	info := &NamedCollectionInfo{
+		Name:      stmt.Name,
+		Statement: stmt,
+	}
+
+	if stmt.OnCluster != nil {
+		info.Cluster = *stmt.OnCluster
+	}
+
+	if stmt.Comment != nil {
+		info.Comment = removeQuotes(*stmt.Comment)
+	}
+
+	if stmt.GlobalOverride != nil {
+		overridable := stmt.GlobalOverride.IsOverridable()
+		info.Overridable = &overridable
+	}
+
+	// Extract parameters
+	if len(stmt.Parameters) > 0 {
+		info.Parameters = make(map[string]string)
+		for _, param := range stmt.Parameters {
+			info.Parameters[param.Key] = param.Value.GetValue()
+		}
+	}
+
+	return info
+}
+
+// generateNamedCollectionDiffs compares current and target named collections and generates differences.
+// This function identifies what changes need to be made to transform the current state
+// into the target state, generating appropriate SQL migration statements.
+func generateNamedCollectionDiffs(current, target map[string]*NamedCollectionInfo) ([]*NamedCollectionDiff, error) {
+	var diffs []*NamedCollectionDiff
+
+	// Get sorted list of all collection names for deterministic processing
+	allNames := make(map[string]bool)
+	for name := range current {
+		allNames[name] = true
+	}
+	for name := range target {
+		allNames[name] = true
+	}
+
+	names := make([]string, 0, len(allNames))
+	for name := range allNames {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Check for renames first to avoid DROP+CREATE
+	processedCurrent := make(map[string]bool)
+	processedTarget := make(map[string]bool)
+
+	for _, currentName := range names {
+		if processedCurrent[currentName] {
+			continue
+		}
+		currentInfo, existsCurrent := current[currentName]
+		if !existsCurrent {
+			continue
+		}
+
+		// Look for a matching collection in target with different name (potential rename)
+		for _, targetName := range names {
+			if processedTarget[targetName] || targetName == currentName {
+				continue
+			}
+			targetInfo, existsTarget := target[targetName]
+			if !existsTarget {
+				continue
+			}
+
+			// Check if this looks like a rename (same properties, different names)
+			if isNamedCollectionRename(currentInfo, targetInfo) {
+				// Generate rename diff
+				diff := generateNamedCollectionRenameDiff(currentInfo, targetInfo)
+				diffs = append(diffs, diff)
+
+				processedCurrent[currentName] = true
+				processedTarget[targetName] = true
+				break
+			}
+		}
+	}
+
+	// Process remaining collections
+	for _, name := range names {
+		if processedCurrent[name] && processedTarget[name] {
+			continue // Already processed as rename
+		}
+
+		currentInfo := current[name]
+		targetInfo := target[name]
+
+		switch {
+		case currentInfo == nil && targetInfo != nil:
+			// Collection needs to be created
+			diff := generateNamedCollectionCreateDiff(targetInfo)
+			diffs = append(diffs, diff)
+
+		case currentInfo != nil && targetInfo == nil:
+			// Collection needs to be dropped
+			diff := generateNamedCollectionDropDiff(currentInfo)
+			diffs = append(diffs, diff)
+
+		case currentInfo != nil && targetInfo != nil:
+			// Collection exists in both - check if it needs modification
+			if !areNamedCollectionsEqual(currentInfo, targetInfo) {
+				// Generate replace diff (ALTER operations are complex, so we use CREATE OR REPLACE)
+				diff := generateNamedCollectionReplaceDiff(currentInfo, targetInfo)
+				diffs = append(diffs, diff)
+			}
+		}
+	}
+
+	return diffs, nil
+}
+
+// isNamedCollectionRename checks if two named collections represent a rename operation
+func isNamedCollectionRename(current, target *NamedCollectionInfo) bool {
+	// Must have same properties except for name
+	return current.Cluster == target.Cluster &&
+		current.Comment == target.Comment &&
+		areParametersEqual(current.Parameters, target.Parameters) &&
+		areOverridesEqual(current.Overridable, target.Overridable)
+}
+
+// areNamedCollectionsEqual checks if two named collections are identical
+func areNamedCollectionsEqual(current, target *NamedCollectionInfo) bool {
+	return current.Name == target.Name &&
+		current.Cluster == target.Cluster &&
+		current.Comment == target.Comment &&
+		areParametersEqual(current.Parameters, target.Parameters) &&
+		areOverridesEqual(current.Overridable, target.Overridable)
+}
+
+// areParametersEqual checks if two parameter maps are equal
+func areParametersEqual(current, target map[string]string) bool {
+	if len(current) != len(target) {
+		return false
+	}
+	for key, value := range current {
+		if targetValue, exists := target[key]; !exists || targetValue != value {
+			return false
+		}
+	}
+	return true
+}
+
+// areOverridesEqual checks if two override settings are equal
+func areOverridesEqual(current, target *bool) bool {
+	if current == nil && target == nil {
+		return true
+	}
+	if current == nil || target == nil {
+		return false
+	}
+	return *current == *target
+}
+
+// generateNamedCollectionCreateDiff generates a CREATE NAMED COLLECTION diff
+func generateNamedCollectionCreateDiff(info *NamedCollectionInfo) *NamedCollectionDiff {
+	upSQL := generateCreateNamedCollectionSQL(info.Statement)
+
+	downSQL := fmt.Sprintf("DROP NAMED COLLECTION IF EXISTS `%s`", info.Name)
+	if info.Cluster != "" {
+		downSQL += fmt.Sprintf(" ON CLUSTER `%s`", info.Cluster)
+	}
+	downSQL += ";"
+
+	return &NamedCollectionDiff{
+		Type:           NamedCollectionDiffCreate,
+		CollectionName: info.Name,
+		Description:    fmt.Sprintf("Create named collection '%s'", info.Name),
+		UpSQL:          upSQL,
+		DownSQL:        downSQL,
+		Target:         info,
+	}
+}
+
+// generateNamedCollectionDropDiff generates a DROP NAMED COLLECTION diff
+func generateNamedCollectionDropDiff(info *NamedCollectionInfo) *NamedCollectionDiff {
+	upSQL := "DROP NAMED COLLECTION IF EXISTS " + utils.BacktickIdentifier(info.Name)
+	if info.Cluster != "" {
+		upSQL += " ON CLUSTER " + utils.BacktickIdentifier(info.Cluster)
+	}
+	upSQL += ";"
+
+	downSQL := generateCreateNamedCollectionSQL(info.Statement)
+
+	return &NamedCollectionDiff{
+		Type:           NamedCollectionDiffDrop,
+		CollectionName: info.Name,
+		Description:    fmt.Sprintf("Drop named collection '%s'", info.Name),
+		UpSQL:          upSQL,
+		DownSQL:        downSQL,
+		Current:        info,
+	}
+}
+
+// generateNamedCollectionReplaceDiff generates a CREATE OR REPLACE NAMED COLLECTION diff
+func generateNamedCollectionReplaceDiff(current, target *NamedCollectionInfo) *NamedCollectionDiff {
+	// Create the target statement with OR REPLACE
+	targetStmt := *target.Statement
+	targetStmt.OrReplace = true
+
+	upSQL := generateCreateNamedCollectionSQL(&targetStmt)
+
+	downSQL := generateCreateNamedCollectionSQL(current.Statement)
+
+	return &NamedCollectionDiff{
+		Type:           NamedCollectionDiffReplace,
+		CollectionName: target.Name,
+		Description:    fmt.Sprintf("Replace named collection '%s'", target.Name),
+		UpSQL:          upSQL,
+		DownSQL:        downSQL,
+		Current:        current,
+		Target:         target,
+	}
+}
+
+// generateNamedCollectionRenameDiff generates a rename diff for named collections
+func generateNamedCollectionRenameDiff(current, target *NamedCollectionInfo) *NamedCollectionDiff {
+	// Named collections don't have a RENAME statement, so we use CREATE OR REPLACE + DROP
+	// First create with new name, then drop old name
+
+	// Create the target statement with OR REPLACE
+	targetStmt := *target.Statement
+	targetStmt.OrReplace = true
+
+	upSQL := generateCreateNamedCollectionSQL(&targetStmt)
+	upSQL += "\n"
+	upSQL += "DROP NAMED COLLECTION IF EXISTS " + utils.BacktickIdentifier(current.Name)
+	if current.Cluster != "" {
+		upSQL += " ON CLUSTER " + utils.BacktickIdentifier(current.Cluster)
+	}
+	upSQL += ";"
+
+	// Down migration recreates the old one and drops the new one
+	downSQL := generateCreateNamedCollectionSQL(current.Statement)
+	downSQL += "\n"
+	downSQL += "DROP NAMED COLLECTION IF EXISTS " + utils.BacktickIdentifier(target.Name)
+	if target.Cluster != "" {
+		downSQL += " ON CLUSTER " + utils.BacktickIdentifier(target.Cluster)
+	}
+	downSQL += ";"
+
+	return &NamedCollectionDiff{
+		Type:              NamedCollectionDiffRename,
+		CollectionName:    current.Name,
+		NewCollectionName: target.Name,
+		Description:       fmt.Sprintf("Rename named collection '%s' to '%s'", current.Name, target.Name),
+		UpSQL:             upSQL,
+		DownSQL:           downSQL,
+		Current:           current,
+		Target:            target,
+	}
+}
+
+// generateCreateNamedCollectionSQL generates a CREATE NAMED COLLECTION SQL statement from a parsed statement
+func generateCreateNamedCollectionSQL(stmt *parser.CreateNamedCollectionStmt) string {
+	var parts []string
+
+	// CREATE [OR REPLACE] NAMED COLLECTION
+	parts = append(parts, "CREATE")
+	if stmt.OrReplace {
+		parts = append(parts, "OR REPLACE")
+	}
+	parts = append(parts, "NAMED COLLECTION")
+
+	// IF NOT EXISTS
+	if stmt.IfNotExists != nil {
+		parts = append(parts, "IF NOT EXISTS")
+	}
+
+	// Collection name
+	parts = append(parts, utils.BacktickIdentifier(stmt.Name))
+
+	// ON CLUSTER
+	if stmt.OnCluster != nil {
+		parts = append(parts, "ON CLUSTER", utils.BacktickIdentifier(*stmt.OnCluster))
+	}
+
+	// AS
+	parts = append(parts, "AS")
+
+	header := strings.Join(parts, " ")
+
+	// Parameters
+	paramLines := make([]string, 0, len(stmt.Parameters))
+	for _, param := range stmt.Parameters {
+		paramLine := fmt.Sprintf("    %s = %s", utils.BacktickIdentifier(param.Key), param.Value.GetValue())
+
+		// Add override clause if present
+		if param.Override != nil {
+			if param.Override.NotOverridable {
+				paramLine += " NOT OVERRIDABLE"
+			} else if param.Override.Overridable {
+				paramLine += " OVERRIDABLE"
+			}
+		}
+
+		paramLines = append(paramLines, paramLine)
+	}
+
+	result := header
+	if len(paramLines) > 0 {
+		result += "\n" + strings.Join(paramLines, ",\n")
+	}
+
+	// Global override
+	if stmt.GlobalOverride != nil {
+		if stmt.GlobalOverride.NotOverridable {
+			result += "\nNOT OVERRIDABLE"
+		} else if stmt.GlobalOverride.Overridable {
+			result += "\nOVERRIDABLE"
+		}
+	}
+
+	// Comment
+	if stmt.Comment != nil {
+		result += "\nCOMMENT " + *stmt.Comment
+	}
+
+	result += ";"
+	return result
+}
+
+// compareNamedCollections compares current and target named collections and generates diffs
+func compareNamedCollections(current, target *parser.SQL) ([]*NamedCollectionDiff, error) {
+	currentCollections := extractNamedCollections(current)
+	targetCollections := extractNamedCollections(target)
+
+	return generateNamedCollectionDiffs(currentCollections, targetCollections)
+}
+
+// extractNamedCollections extracts named collection information from SQL statements
+func extractNamedCollections(sql *parser.SQL) map[string]*NamedCollectionInfo {
+	collections := make(map[string]*NamedCollectionInfo)
+
+	if sql == nil {
+		return collections
+	}
+
+	for _, stmt := range sql.Statements {
+		if stmt.CreateNamedCollection != nil {
+			info := extractNamedCollectionInfo(stmt.CreateNamedCollection)
+			collections[info.Name] = info
+		}
+	}
+
+	return collections
+}

--- a/pkg/utils/doc.go
+++ b/pkg/utils/doc.go
@@ -1,0 +1,97 @@
+// Package utils provides common utility functions used throughout the Housekeeper codebase.
+//
+// This package contains shared utilities that are used by multiple packages to avoid
+// code duplication and ensure consistent behavior across the application.
+//
+// # Identifier Utilities (identifier.go)
+//
+// The identifier utilities provide consistent handling of ClickHouse SQL identifiers,
+// including proper backtick quoting for names that may contain special characters or
+// reserved keywords.
+//
+// # Value Type Utilities (validation.go)
+//
+// The value type utilities provide proper validation for different data types commonly
+// used in ClickHouse SQL generation, particularly for named collection parameters and
+// other configuration values.
+//
+// ## BacktickIdentifier
+//
+// The primary function for adding backticks to identifiers, handling both simple
+// and qualified names:
+//
+//	// Simple identifier
+//	name := utils.BacktickIdentifier("users")
+//	// Result: `users`
+//
+//	// Qualified identifier
+//	qualified := utils.BacktickIdentifier("analytics.events")
+//	// Result: `analytics`.`events`
+//
+//	// Already backticked (not double-backticked)
+//	existing := utils.BacktickIdentifier("`users`")
+//	// Result: `users`
+//
+// ## BacktickQualifiedName
+//
+// Specialized function for database-qualified names, commonly used for tables,
+// views, and dictionaries:
+//
+//	db := "analytics"
+//	table := "events"
+//	qualified := utils.BacktickQualifiedName(&db, table)
+//	// Result: `analytics`.`events`
+//
+//	// Without database prefix
+//	simple := utils.BacktickQualifiedName(nil, "users")
+//	// Result: `users`
+//
+// ## Helper Functions
+//
+// Additional utilities for working with backticked identifiers:
+//
+//	// Check if already backticked
+//	if utils.IsBackticked(name) {
+//		// Already has backticks
+//	}
+//
+//	// Remove backticks
+//	clean := utils.StripBackticks("`database`.`table`")
+//	// Result: database.table
+//
+// ## IsNumericValue and IsBooleanValue
+//
+// Value type validation functions for properly formatting SQL values:
+//
+//	// Validate numeric values (uses strconv.ParseFloat)
+//	if utils.IsNumericValue("123.45") {
+//		// Can be used without quotes in SQL
+//	}
+//
+//	// Validate boolean values (case-insensitive)
+//	if utils.IsBooleanValue("TRUE") {
+//		// Can be used without quotes in SQL
+//	}
+//
+//	// Example usage for SQL value formatting
+//	value := "123.45"
+//	if utils.IsNumericValue(value) || utils.IsBooleanValue(value) {
+//		sql += value // No quotes needed
+//	} else {
+//		sql += "'" + value + "'" // Add quotes for string values
+//	}
+//
+// # Usage Guidelines
+//
+// These utilities should be used whenever generating or manipulating SQL identifiers
+// to ensure consistent formatting across all generated DDL statements. They handle
+// edge cases like:
+//
+//   - Identifiers that are already backticked
+//   - Qualified names with multiple parts (database.schema.table)
+//   - Empty strings and nil pointers
+//   - Special characters in identifiers
+//
+// The utilities are designed to be safe and idempotent - calling BacktickIdentifier
+// on an already backticked identifier will not double-backtick it.
+package utils

--- a/pkg/utils/identifier.go
+++ b/pkg/utils/identifier.go
@@ -1,0 +1,83 @@
+package utils
+
+import "strings"
+
+// BacktickIdentifier adds backticks around an identifier, handling nested identifiers.
+// It properly handles database.table.column style identifiers by backticking each part.
+//
+// Examples:
+//   - "table" -> "`table`"
+//   - "database.table" -> "`database`.`table`"
+//   - "db.schema.table" -> "`db`.`schema`.`table`"
+//   - "`table`" -> "`table`" (already backticked, not double-backticked)
+//   - "" -> ""
+//
+// This function is used throughout the codebase for consistent identifier formatting
+// in generated DDL statements.
+func BacktickIdentifier(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	// If the entire string is already backticked and doesn't contain dots outside backticks,
+	// return as-is (it's a single identifier that happens to contain dots)
+	if len(name) >= 2 && name[0] == '`' && name[len(name)-1] == '`' {
+		// Check if there are any backticks in the middle
+		inner := name[1 : len(name)-1]
+		if !strings.Contains(inner, "`") {
+			// This is a single backticked identifier, possibly containing dots
+			return name
+		}
+	}
+
+	// Handle database.table.column format by backticking each part
+	parts := strings.Split(name, ".")
+	for i, part := range parts {
+		// Skip if this part is already backticked
+		if len(part) >= 2 && part[0] == '`' && part[len(part)-1] == '`' {
+			continue
+		}
+		parts[i] = "`" + part + "`"
+	}
+	return strings.Join(parts, ".")
+}
+
+// BacktickQualifiedName formats a qualified name (database.name) with proper backticks.
+// If database is nil or empty, only the name is backticked.
+//
+// Examples:
+//   - ("analytics", "events") -> "`analytics`.`events`"
+//   - (nil, "events") -> "`events`"
+//   - ("", "events") -> "`events`"
+//
+// This is commonly used for formatting table, view, and dictionary names that may
+// include a database prefix.
+func BacktickQualifiedName(database *string, name string) string {
+	if database != nil && *database != "" {
+		return BacktickIdentifier(*database) + "." + BacktickIdentifier(name)
+	}
+	return BacktickIdentifier(name)
+}
+
+// IsBackticked checks if a string is already wrapped in backticks.
+//
+// Examples:
+//   - "`table`" -> true
+//   - "table" -> false
+//   - "`db`.`table`" -> false (qualified name, not a single backticked identifier)
+//   - "" -> false
+func IsBackticked(s string) bool {
+	return len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' && !strings.Contains(s[1:len(s)-1], "`")
+}
+
+// StripBackticks removes backticks from an identifier if present.
+//
+// Examples:
+//   - "`table`" -> "table"
+//   - "table" -> "table"
+//   - "`db`.`table`" -> "db.table"
+//   - "" -> ""
+func StripBackticks(s string) string {
+	// Remove all backticks
+	return strings.ReplaceAll(s, "`", "")
+}

--- a/pkg/utils/identifier_test.go
+++ b/pkg/utils/identifier_test.go
@@ -1,0 +1,276 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/pseudomuto/housekeeper/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBacktickIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple identifier",
+			input:    "table",
+			expected: "`table`",
+		},
+		{
+			name:     "qualified identifier with two parts",
+			input:    "database.table",
+			expected: "`database`.`table`",
+		},
+		{
+			name:     "qualified identifier with three parts",
+			input:    "database.schema.table",
+			expected: "`database`.`schema`.`table`",
+		},
+		{
+			name:     "already backticked simple identifier",
+			input:    "`table`",
+			expected: "`table`",
+		},
+		{
+			name:     "partially backticked qualified identifier",
+			input:    "`database`.table",
+			expected: "`database`.`table`",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "identifier with spaces",
+			input:    "my table",
+			expected: "`my table`",
+		},
+		{
+			name:     "identifier with special characters",
+			input:    "table-name",
+			expected: "`table-name`",
+		},
+		{
+			name:     "qualified identifier with spaces",
+			input:    "my database.my table",
+			expected: "`my database`.`my table`",
+		},
+		{
+			name:     "already fully backticked qualified identifier",
+			input:    "`database`.`table`",
+			expected: "`database`.`table`",
+		},
+		{
+			name:     "mixed backticks in qualified identifier",
+			input:    "database.`table`",
+			expected: "`database`.`table`",
+		},
+		{
+			name:     "single character identifier",
+			input:    "a",
+			expected: "`a`",
+		},
+		{
+			name:     "numeric identifier",
+			input:    "123",
+			expected: "`123`",
+		},
+		{
+			name:     "identifier with dots in backticks",
+			input:    "`db.table`",
+			expected: "`db.table`", // Treat as already backticked single identifier
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.BacktickIdentifier(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBacktickQualifiedName(t *testing.T) {
+	tests := []struct {
+		name     string
+		database *string
+		table    string
+		expected string
+	}{
+		{
+			name:     "with database",
+			database: stringPtr("analytics"),
+			table:    "events",
+			expected: "`analytics`.`events`",
+		},
+		{
+			name:     "without database (nil)",
+			database: nil,
+			table:    "events",
+			expected: "`events`",
+		},
+		{
+			name:     "without database (empty string)",
+			database: stringPtr(""),
+			table:    "events",
+			expected: "`events`",
+		},
+		{
+			name:     "already backticked database",
+			database: stringPtr("`analytics`"),
+			table:    "events",
+			expected: "`analytics`.`events`",
+		},
+		{
+			name:     "already backticked table",
+			database: stringPtr("analytics"),
+			table:    "`events`",
+			expected: "`analytics`.`events`",
+		},
+		{
+			name:     "both already backticked",
+			database: stringPtr("`analytics`"),
+			table:    "`events`",
+			expected: "`analytics`.`events`",
+		},
+		{
+			name:     "database with special characters",
+			database: stringPtr("my-database"),
+			table:    "my_table",
+			expected: "`my-database`.`my_table`",
+		},
+		{
+			name:     "empty table name",
+			database: stringPtr("analytics"),
+			table:    "",
+			expected: "`analytics`.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.BacktickQualifiedName(tt.database, tt.table)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsBackticked(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "backticked identifier",
+			input:    "`table`",
+			expected: true,
+		},
+		{
+			name:     "not backticked",
+			input:    "table",
+			expected: false,
+		},
+		{
+			name:     "qualified backticked identifier",
+			input:    "`database`.`table`",
+			expected: false, // This is a qualified name, not a single backticked identifier
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "single backtick",
+			input:    "`",
+			expected: false,
+		},
+		{
+			name:     "mismatched backticks",
+			input:    "`table",
+			expected: false,
+		},
+		{
+			name:     "backticks with content containing backticks",
+			input:    "`ta`ble`",
+			expected: false, // Contains backticks in the middle
+		},
+		{
+			name:     "just two backticks",
+			input:    "``",
+			expected: true,
+		},
+		{
+			name:     "backticked identifier with spaces",
+			input:    "`my table`",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.IsBackticked(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestStripBackticks(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "backticked identifier",
+			input:    "`table`",
+			expected: "table",
+		},
+		{
+			name:     "not backticked",
+			input:    "table",
+			expected: "table",
+		},
+		{
+			name:     "qualified backticked identifier",
+			input:    "`database`.`table`",
+			expected: "database.table",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "multiple backticks",
+			input:    "``table``",
+			expected: "table",
+		},
+		{
+			name:     "backticks in the middle",
+			input:    "ta`ble",
+			expected: "table",
+		},
+		{
+			name:     "mixed backticks",
+			input:    "`database`.table.`column`",
+			expected: "database.table.column",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.StripBackticks(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"strconv"
+	"strings"
+)
+
+// IsNumericValue checks if a string represents a valid numeric value.
+// This uses strconv.ParseFloat to properly validate numeric formats,
+// including integers, floats, and scientific notation.
+//
+// Examples:
+//   - "123" -> true
+//   - "123.45" -> true
+//   - "-123.45" -> true
+//   - "1.23e-4" -> true (scientific notation)
+//   - "1.23E+5" -> true (scientific notation)
+//   - "abc" -> false
+//   - "1.2.3" -> false (multiple decimal points)
+//   - "" -> false
+//   - "." -> false
+//   - "-" -> false
+func IsNumericValue(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	_, err := strconv.ParseFloat(value, 64)
+	return err == nil
+}
+
+// IsBooleanValue checks if a string represents a boolean value.
+// This is case-insensitive and supports various boolean representations.
+//
+// Examples:
+//   - "true" -> true
+//   - "TRUE" -> true
+//   - "True" -> true
+//   - "false" -> true
+//   - "FALSE" -> true
+//   - "1" -> false (use IsNumericValue for numeric booleans)
+//   - "yes" -> false
+//   - "" -> false
+func IsBooleanValue(value string) bool {
+	lowered := strings.ToLower(value)
+	return lowered == "true" || lowered == "false"
+}

--- a/pkg/utils/validation_test.go
+++ b/pkg/utils/validation_test.go
@@ -1,0 +1,266 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/pseudomuto/housekeeper/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNumericValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Valid numeric values
+		{
+			name:     "positive integer",
+			input:    "123",
+			expected: true,
+		},
+		{
+			name:     "negative integer",
+			input:    "-123",
+			expected: true,
+		},
+		{
+			name:     "positive float",
+			input:    "123.45",
+			expected: true,
+		},
+		{
+			name:     "negative float",
+			input:    "-123.45",
+			expected: true,
+		},
+		{
+			name:     "float without integer part",
+			input:    ".123",
+			expected: true,
+		},
+		{
+			name:     "negative float without integer part",
+			input:    "-.123",
+			expected: true,
+		},
+		{
+			name:     "float without decimal part",
+			input:    "123.",
+			expected: true,
+		},
+		{
+			name:     "scientific notation lowercase e",
+			input:    "1.23e4",
+			expected: true,
+		},
+		{
+			name:     "scientific notation uppercase E",
+			input:    "1.23E4",
+			expected: true,
+		},
+		{
+			name:     "scientific notation with positive exponent",
+			input:    "1.23e+4",
+			expected: true,
+		},
+		{
+			name:     "scientific notation with negative exponent",
+			input:    "1.23e-4",
+			expected: true,
+		},
+		{
+			name:     "zero",
+			input:    "0",
+			expected: true,
+		},
+		{
+			name:     "negative zero",
+			input:    "-0",
+			expected: true,
+		},
+		{
+			name:     "zero float",
+			input:    "0.0",
+			expected: true,
+		},
+
+		// Invalid numeric values
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "just period",
+			input:    ".",
+			expected: false,
+		},
+		{
+			name:     "just minus",
+			input:    "-",
+			expected: false,
+		},
+		{
+			name:     "multiple decimal points",
+			input:    "1.2.3",
+			expected: false,
+		},
+		{
+			name:     "letters",
+			input:    "abc",
+			expected: false,
+		},
+		{
+			name:     "mixed letters and numbers",
+			input:    "123abc",
+			expected: false,
+		},
+		{
+			name:     "invalid scientific notation",
+			input:    "1.23e",
+			expected: false,
+		},
+		{
+			name:     "double negative",
+			input:    "--123",
+			expected: false,
+		},
+		{
+			name:     "minus in middle",
+			input:    "12-3",
+			expected: false,
+		},
+		{
+			name:     "spaces",
+			input:    "1 2 3",
+			expected: false,
+		},
+		{
+			name:     "leading/trailing spaces",
+			input:    " 123 ",
+			expected: false,
+		},
+		{
+			name:     "plus sign (should be invalid for ClickHouse)",
+			input:    "+123",
+			expected: true, // ParseFloat accepts this, but we might want to reject it
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.IsNumericValue(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsBooleanValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		// Valid boolean values
+		{
+			name:     "lowercase true",
+			input:    "true",
+			expected: true,
+		},
+		{
+			name:     "uppercase TRUE",
+			input:    "TRUE",
+			expected: true,
+		},
+		{
+			name:     "mixed case True",
+			input:    "True",
+			expected: true,
+		},
+		{
+			name:     "mixed case tRuE",
+			input:    "tRuE",
+			expected: true,
+		},
+		{
+			name:     "lowercase false",
+			input:    "false",
+			expected: true,
+		},
+		{
+			name:     "uppercase FALSE",
+			input:    "FALSE",
+			expected: true,
+		},
+		{
+			name:     "mixed case False",
+			input:    "False",
+			expected: true,
+		},
+		{
+			name:     "mixed case fAlSe",
+			input:    "fAlSe",
+			expected: true,
+		},
+
+		// Invalid boolean values
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "numeric 1",
+			input:    "1",
+			expected: false,
+		},
+		{
+			name:     "numeric 0",
+			input:    "0",
+			expected: false,
+		},
+		{
+			name:     "yes",
+			input:    "yes",
+			expected: false,
+		},
+		{
+			name:     "no",
+			input:    "no",
+			expected: false,
+		},
+		{
+			name:     "on",
+			input:    "on",
+			expected: false,
+		},
+		{
+			name:     "off",
+			input:    "off",
+			expected: false,
+		},
+		{
+			name:     "t",
+			input:    "t",
+			expected: false,
+		},
+		{
+			name:     "f",
+			input:    "f",
+			expected: false,
+		},
+		{
+			name:     "with spaces",
+			input:    " true ",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.IsBooleanValue(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Implement complete support for ClickHouse named collections across all packages including parser, formatter, schema migration, ClickHouse client integration, and project structure. Named collections provide centralized credential and connection parameter management that can be referenced by integration engines like Kafka, MySQL, and PostgreSQL tables.

This addresses the need for better credential management in ClickHouse deployments and provides proper dependency ordering in migrations since integration engine tables may reference named collections.

Key changes include:
- Add named collection parsing with CREATE/ALTER/DROP statement support
- Add formatter support with proper OVERRIDABLE flag handling and parameter formatting
- Add schema migration generation with CREATE, DROP, REPLACE, and RENAME operations
- Add ClickHouse client integration with system.named_collections extraction
- Add project structure support with collections/ directory organization
- Add migration ordering with named collections processed before tables
- Add documentation updates including migration operations support table
- Add test coverage for all parser, formatter, schema, and project functionality

All lint issues resolved and comprehensive test coverage added across parser, formatter, schema migration, ClickHouse client, and project packages.

fixes #27