### PR TITLE
[clickhouse]: Use AST-based normalization for DDL statements

### DIFF
--- a/pkg/clickhouse/utils_test.go
+++ b/pkg/clickhouse/utils_test.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,83 @@ func TestBuildSystemDatabaseExclusion(t *testing.T) {
 			query, params := buildSystemDatabaseExclusion(tt.columnName)
 			require.Equal(t, tt.expectedQuery, query)
 			require.Equal(t, tt.expectedParams, params)
+		})
+	}
+}
+
+func TestNormalizeDataTypesInDDL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Hidden password normalization",
+			input:    "SOURCE(HTTP(url 'http://example.com', user 'user', password '[HIDDEN]'))",
+			expected: "SOURCE(HTTP(url 'http://example.com', user 'user', password ''))",
+		},
+		{
+			name:     "Case insensitive password normalization",
+			input:    "SOURCE(HTTP(url 'http://example.com', PASSWORD '[HIDDEN]'))",
+			expected: "SOURCE(HTTP(url 'http://example.com', password ''))",
+		},
+		{
+			name:     "Float default normalization with space",
+			input:    "CREATE TABLE test (score Float32 DEFAULT 0. ) ENGINE = MergeTree();",
+			expected: "CREATE TABLE test (score Float32 DEFAULT 0.0 ) ENGINE = MergeTree();",
+		},
+		{
+			name:     "Float default normalization at end",
+			input:    "score Float32 DEFAULT 0.",
+			expected: "score Float32 DEFAULT 0.0",
+		},
+		{
+			name:     "LIFETIME normalization",
+			input:    "LIFETIME(MIN 0 MAX 3600)",
+			expected: "LIFETIME(3600)",
+		},
+		{
+			name:     "No normalization needed",
+			input:    "CREATE TABLE test (col String) ENGINE = MergeTree();",
+			expected: "CREATE TABLE test (col String) ENGINE = MergeTree();",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeDataTypesInDDL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCleanCreateStatement(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Add missing semicolon and format via AST",
+			input:    "CREATE TABLE test (id UInt64) ENGINE = MergeTree()",
+			expected: "CREATE TABLE `test` (\n    `id` UInt64\n)\nENGINE = MergeTree();",
+		},
+		{
+			name:     "Parse and reformat for consistency",
+			input:    "CREATE TABLE test (id UInt64) ENGINE = MergeTree();",
+			expected: "CREATE TABLE `test` (\n    `id` UInt64\n)\nENGINE = MergeTree();",
+		},
+		{
+			name:     "Complex AggregateFunction should be preserved",
+			input:    "CREATE TABLE test (col AggregateFunction(quantiles(0.5, 0.75, 0.9), Float64)) ENGINE = MergeTree();",
+			expected: "CREATE TABLE `test` (\n    `col` AggregateFunction(quantiles(0.5, 0.75, 0.9), Float64)\n)\nENGINE = MergeTree();",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cleanCreateStatement(tt.input)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
The previous approach used fragile string manipulation with multiple regex patterns that could corrupt complex type definitions. This was particularly problematic for AggregateFunction types with nested function calls like quantiles(0.5, 0.75, 0.90, 0.95, 0.99).

This change replaces the string manipulation approach with an AST-based solution that parses DDL statements and reformats them using the existing parser and formatter. This ensures consistency while preserving complex type signatures.

Changes:
- Replace cleanCreateStatement with AST parse/format approach
- Reduce normalizeDataTypesInDDL to only essential cases
- Remove potentially destructive regex patterns
- Add comprehensive tests for both functions
- Preserve complex AggregateFunction signatures correctly