### PR TITLE
[parser|format]: Add AST-based comment support across all DDL types

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -273,6 +273,11 @@ COMMENT 'Table used to track migrations';
 
 	// Execute bootstrap statements
 	for _, stmt := range sql.Statements {
+		// Skip comment-only statements as they cannot be executed
+		if stmt.CommentStatement != nil {
+			continue
+		}
+
 		stmtSQL, err := e.formatStatement(stmt)
 		if err != nil {
 			return errors.Wrap(err, "failed to format bootstrap statement")
@@ -325,6 +330,13 @@ func (e *Executor) executeMigration(ctx context.Context, migration *migrator.Mig
 
 	for i := startIndex; i < len(migration.Statements); i++ {
 		stmt := migration.Statements[i]
+
+		// Skip comment-only statements as they cannot be executed
+		if stmt.CommentStatement != nil {
+			statementsApplied++
+			continue
+		}
+
 		stmtSQL, err := e.formatStatement(stmt)
 		if err != nil {
 			executionError = errors.Wrapf(err, "failed to format statement %d", i+1)

--- a/pkg/format/database.go
+++ b/pkg/format/database.go
@@ -9,172 +9,184 @@ import (
 
 // CreateDatabase formats a CREATE DATABASE statement
 func (f *Formatter) createDatabase(w io.Writer, stmt *parser.CreateDatabaseStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// CREATE DATABASE
-	parts = append(parts, f.keyword("CREATE DATABASE"))
+		// CREATE DATABASE
+		parts = append(parts, f.keyword("CREATE DATABASE"))
 
-	// IF NOT EXISTS
-	if stmt.IfNotExists {
-		parts = append(parts, f.keyword("IF NOT EXISTS"))
-	}
+		// IF NOT EXISTS
+		if stmt.IfNotExists {
+			parts = append(parts, f.keyword("IF NOT EXISTS"))
+		}
 
-	// Database name
-	parts = append(parts, f.identifier(stmt.Name))
+		// Database name
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// ENGINE
-	if stmt.Engine != nil {
-		parts = append(parts, f.keyword("ENGINE"), "=", f.formatDatabaseEngine(stmt.Engine))
-	}
+		// ENGINE
+		if stmt.Engine != nil {
+			parts = append(parts, f.keyword("ENGINE"), "=", f.formatDatabaseEngine(stmt.Engine))
+		}
 
-	// COMMENT
-	if stmt.Comment != nil {
-		parts = append(parts, f.keyword("COMMENT"), *stmt.Comment)
-	}
+		// COMMENT
+		if stmt.Comment != nil {
+			parts = append(parts, f.keyword("COMMENT"), *stmt.Comment)
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // AlterDatabase formats an ALTER DATABASE statement
 func (f *Formatter) alterDatabase(w io.Writer, stmt *parser.AlterDatabaseStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// ALTER DATABASE
-	parts = append(parts, f.keyword("ALTER DATABASE"), f.identifier(stmt.Name))
+		// ALTER DATABASE
+		parts = append(parts, f.keyword("ALTER DATABASE"), f.identifier(stmt.Name))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// Action
-	if stmt.Action != nil && stmt.Action.ModifyComment != nil {
-		parts = append(parts, f.keyword("MODIFY COMMENT"), *stmt.Action.ModifyComment)
-	}
+		// Action
+		if stmt.Action != nil && stmt.Action.ModifyComment != nil {
+			parts = append(parts, f.keyword("MODIFY COMMENT"), *stmt.Action.ModifyComment)
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // AttachDatabase formats an ATTACH DATABASE statement
 func (f *Formatter) attachDatabase(w io.Writer, stmt *parser.AttachDatabaseStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// ATTACH DATABASE
-	parts = append(parts, f.keyword("ATTACH DATABASE"))
+		// ATTACH DATABASE
+		parts = append(parts, f.keyword("ATTACH DATABASE"))
 
-	// IF NOT EXISTS
-	if stmt.IfNotExists {
-		parts = append(parts, f.keyword("IF NOT EXISTS"))
-	}
+		// IF NOT EXISTS
+		if stmt.IfNotExists {
+			parts = append(parts, f.keyword("IF NOT EXISTS"))
+		}
 
-	// Database name
-	parts = append(parts, f.identifier(stmt.Name))
+		// Database name
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// ENGINE
-	if stmt.Engine != nil {
-		parts = append(parts, f.keyword("ENGINE"), "=", f.formatDatabaseEngine(stmt.Engine))
-	}
+		// ENGINE
+		if stmt.Engine != nil {
+			parts = append(parts, f.keyword("ENGINE"), "=", f.formatDatabaseEngine(stmt.Engine))
+		}
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // DetachDatabase formats a DETACH DATABASE statement
 func (f *Formatter) detachDatabase(w io.Writer, stmt *parser.DetachDatabaseStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// DETACH DATABASE
-	parts = append(parts, f.keyword("DETACH DATABASE"))
+		// DETACH DATABASE
+		parts = append(parts, f.keyword("DETACH DATABASE"))
 
-	// IF EXISTS
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("IF EXISTS"))
-	}
+		// IF EXISTS
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("IF EXISTS"))
+		}
 
-	// Database name
-	parts = append(parts, f.identifier(stmt.Name))
+		// Database name
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// PERMANENTLY
-	if stmt.Permanently {
-		parts = append(parts, f.keyword("PERMANENTLY"))
-	}
+		// PERMANENTLY
+		if stmt.Permanently {
+			parts = append(parts, f.keyword("PERMANENTLY"))
+		}
 
-	// SYNC
-	if stmt.Sync {
-		parts = append(parts, f.keyword("SYNC"))
-	}
+		// SYNC
+		if stmt.Sync {
+			parts = append(parts, f.keyword("SYNC"))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // DropDatabase formats a DROP DATABASE statement
 func (f *Formatter) dropDatabase(w io.Writer, stmt *parser.DropDatabaseStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// DROP DATABASE
-	parts = append(parts, f.keyword("DROP DATABASE"))
+		// DROP DATABASE
+		parts = append(parts, f.keyword("DROP DATABASE"))
 
-	// IF EXISTS
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("IF EXISTS"))
-	}
+		// IF EXISTS
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("IF EXISTS"))
+		}
 
-	// Database name
-	parts = append(parts, f.identifier(stmt.Name))
+		// Database name
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// SYNC
-	if stmt.Sync {
-		parts = append(parts, f.keyword("SYNC"))
-	}
+		// SYNC
+		if stmt.Sync {
+			parts = append(parts, f.keyword("SYNC"))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // RenameDatabase formats a RENAME DATABASE statement
 func (f *Formatter) renameDatabase(w io.Writer, stmt *parser.RenameDatabaseStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// RENAME DATABASE
-	parts = append(parts, f.keyword("RENAME DATABASE"))
+		// RENAME DATABASE
+		parts = append(parts, f.keyword("RENAME DATABASE"))
 
-	// Renames
-	renameParts := make([]string, 0, len(stmt.Renames))
-	for _, rename := range stmt.Renames {
-		renameParts = append(renameParts, f.identifier(rename.From)+" "+f.keyword("TO")+" "+f.identifier(rename.To))
-	}
-	parts = append(parts, strings.Join(renameParts, ", "))
+		// Renames
+		renameParts := make([]string, 0, len(stmt.Renames))
+		for _, rename := range stmt.Renames {
+			renameParts = append(renameParts, f.identifier(rename.From)+" "+f.keyword("TO")+" "+f.identifier(rename.To))
+		}
+		parts = append(parts, strings.Join(renameParts, ", "))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // formatDatabaseEngine formats a database engine specification

--- a/pkg/format/function.go
+++ b/pkg/format/function.go
@@ -9,82 +9,86 @@ import (
 
 // formatCreateFunction formats CREATE FUNCTION statements
 func (f *Formatter) formatCreateFunction(w io.Writer, stmt *parser.CreateFunctionStmt) error {
-	if _, err := w.Write([]byte(f.keyword("create") + " " + f.keyword("function") + " ")); err != nil {
-		return err
-	}
-
-	if _, err := w.Write([]byte(f.identifier(stmt.Name))); err != nil {
-		return err
-	}
-
-	// Add ON CLUSTER if specified
-	if stmt.OnCluster != nil {
-		if _, err := w.Write([]byte(" " + f.keyword("on") + " " + f.keyword("cluster") + " ")); err != nil {
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		if _, err := w.Write([]byte(f.keyword("create") + " " + f.keyword("function") + " ")); err != nil {
 			return err
 		}
-		if _, err := w.Write([]byte(f.identifier(*stmt.OnCluster))); err != nil {
+
+		if _, err := w.Write([]byte(f.identifier(stmt.Name))); err != nil {
 			return err
 		}
-	}
 
-	// Format AS clause with parameters
-	if _, err := w.Write([]byte(" " + f.keyword("as") + " (")); err != nil {
-		return err
-	}
-
-	// Format parameters
-	for i, param := range stmt.Parameters {
-		if i > 0 {
-			if _, err := w.Write([]byte(", ")); err != nil {
+		// Add ON CLUSTER if specified
+		if stmt.OnCluster != nil {
+			if _, err := w.Write([]byte(" " + f.keyword("on") + " " + f.keyword("cluster") + " ")); err != nil {
+				return err
+			}
+			if _, err := w.Write([]byte(f.identifier(*stmt.OnCluster))); err != nil {
 				return err
 			}
 		}
-		if _, err := w.Write([]byte(f.identifier(param.Name))); err != nil {
+
+		// Format AS clause with parameters
+		if _, err := w.Write([]byte(" " + f.keyword("as") + " (")); err != nil {
 			return err
 		}
-	}
 
-	if _, err := w.Write([]byte(") -> ")); err != nil {
-		return err
-	}
+		// Format parameters
+		for i, param := range stmt.Parameters {
+			if i > 0 {
+				if _, err := w.Write([]byte(", ")); err != nil {
+					return err
+				}
+			}
+			if _, err := w.Write([]byte(f.identifier(param.Name))); err != nil {
+				return err
+			}
+		}
 
-	// Format the expression
-	exprStr := f.formatExpression(stmt.Expression)
-	if _, err := w.Write([]byte(exprStr)); err != nil {
-		return err
-	}
+		if _, err := w.Write([]byte(") -> ")); err != nil {
+			return err
+		}
 
-	if _, err := w.Write([]byte(";")); err != nil {
-		return err
-	}
+		// Format the expression
+		exprStr := f.formatExpression(stmt.Expression)
+		if _, err := w.Write([]byte(exprStr)); err != nil {
+			return err
+		}
 
-	return nil
+		if _, err := w.Write([]byte(";")); err != nil {
+			return err
+		}
+
+		return nil
+	})
 }
 
 // formatDropFunction formats DROP FUNCTION statements
 func (f *Formatter) formatDropFunction(w io.Writer, stmt *parser.DropFunctionStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	parts = append(parts, f.keyword("drop")+" "+f.keyword("function"))
+		parts = append(parts, f.keyword("drop")+" "+f.keyword("function"))
 
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("if")+" "+f.keyword("exists"))
-	}
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("if")+" "+f.keyword("exists"))
+		}
 
-	parts = append(parts, f.identifier(stmt.Name))
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// Add ON CLUSTER if specified
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("on")+" "+f.keyword("cluster"), f.identifier(*stmt.OnCluster))
-	}
+		// Add ON CLUSTER if specified
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("on")+" "+f.keyword("cluster"), f.identifier(*stmt.OnCluster))
+		}
 
-	if _, err := w.Write([]byte(strings.Join(parts, " "))); err != nil {
-		return err
-	}
+		if _, err := w.Write([]byte(strings.Join(parts, " "))); err != nil {
+			return err
+		}
 
-	if _, err := w.Write([]byte(";")); err != nil {
-		return err
-	}
+		if _, err := w.Write([]byte(";")); err != nil {
+			return err
+		}
 
-	return nil
+		return nil
+	})
 }

--- a/pkg/format/role.go
+++ b/pkg/format/role.go
@@ -10,95 +10,101 @@ import (
 
 // createRole formats a CREATE ROLE statement
 func (f *Formatter) createRole(w io.Writer, stmt *parser.CreateRoleStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// CREATE [OR REPLACE] ROLE [IF NOT EXISTS]
-	if stmt.OrReplace {
-		parts = append(parts, f.keyword("CREATE OR REPLACE ROLE"))
-	} else {
-		parts = append(parts, f.keyword("CREATE ROLE"))
-		if stmt.IfNotExists {
-			parts = append(parts, f.keyword("IF NOT EXISTS"))
+		// CREATE [OR REPLACE] ROLE [IF NOT EXISTS]
+		if stmt.OrReplace {
+			parts = append(parts, f.keyword("CREATE OR REPLACE ROLE"))
+		} else {
+			parts = append(parts, f.keyword("CREATE ROLE"))
+			if stmt.IfNotExists {
+				parts = append(parts, f.keyword("IF NOT EXISTS"))
+			}
 		}
-	}
 
-	// Role name
-	parts = append(parts, f.identifier(stmt.Name))
+		// Role name
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// SETTINGS
-	if stmt.Settings != nil {
-		parts = append(parts, f.formatRoleSettings(stmt.Settings))
-	}
+		// SETTINGS
+		if stmt.Settings != nil {
+			parts = append(parts, f.formatRoleSettings(stmt.Settings))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // alterRole formats an ALTER ROLE statement
 func (f *Formatter) alterRole(w io.Writer, stmt *parser.AlterRoleStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// ALTER ROLE
-	parts = append(parts, f.keyword("ALTER ROLE"))
+		// ALTER ROLE
+		parts = append(parts, f.keyword("ALTER ROLE"))
 
-	// IF EXISTS
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("IF EXISTS"))
-	}
+		// IF EXISTS
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("IF EXISTS"))
+		}
 
-	// Role name
-	parts = append(parts, f.identifier(stmt.Name))
+		// Role name
+		parts = append(parts, f.identifier(stmt.Name))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// RENAME TO
-	if stmt.RenameTo != nil {
-		parts = append(parts, f.keyword("RENAME TO"), f.identifier(*stmt.RenameTo))
-	}
+		// RENAME TO
+		if stmt.RenameTo != nil {
+			parts = append(parts, f.keyword("RENAME TO"), f.identifier(*stmt.RenameTo))
+		}
 
-	// SETTINGS
-	if stmt.Settings != nil {
-		parts = append(parts, f.formatRoleSettings(stmt.Settings))
-	}
+		// SETTINGS
+		if stmt.Settings != nil {
+			parts = append(parts, f.formatRoleSettings(stmt.Settings))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // dropRole formats a DROP ROLE statement
 func (f *Formatter) dropRole(w io.Writer, stmt *parser.DropRoleStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// DROP ROLE
-	parts = append(parts, f.keyword("DROP ROLE"))
+		// DROP ROLE
+		parts = append(parts, f.keyword("DROP ROLE"))
 
-	// IF EXISTS
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("IF EXISTS"))
-	}
+		// IF EXISTS
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("IF EXISTS"))
+		}
 
-	// Role names
-	names := make([]string, len(stmt.Names))
-	for i, name := range stmt.Names {
-		names[i] = f.identifier(name)
-	}
-	parts = append(parts, strings.Join(names, ", "))
+		// Role names
+		names := make([]string, len(stmt.Names))
+		for i, name := range stmt.Names {
+			names[i] = f.identifier(name)
+		}
+		parts = append(parts, strings.Join(names, ", "))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // setRole formats a SET ROLE statement
@@ -159,77 +165,81 @@ func (f *Formatter) setDefaultRole(w io.Writer, stmt *parser.SetDefaultRoleStmt)
 
 // grant formats a GRANT statement
 func (f *Formatter) grant(w io.Writer, stmt *parser.GrantStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// GRANT
-	parts = append(parts, f.keyword("GRANT"))
+		// GRANT
+		parts = append(parts, f.keyword("GRANT"))
 
-	// Privileges
-	parts = append(parts, f.formatPrivilegeList(stmt.Privileges))
+		// Privileges
+		parts = append(parts, f.formatPrivilegeList(stmt.Privileges))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// ON target
-	if stmt.On != nil {
-		parts = append(parts, f.keyword("ON"), f.formatGrantTarget(stmt.On))
-	}
+		// ON target
+		if stmt.On != nil {
+			parts = append(parts, f.keyword("ON"), f.formatGrantTarget(stmt.On))
+		}
 
-	// TO grantees
-	parts = append(parts, f.keyword("TO"))
-	parts = append(parts, f.formatGranteeList(stmt.To))
+		// TO grantees
+		parts = append(parts, f.keyword("TO"))
+		parts = append(parts, f.formatGranteeList(stmt.To))
 
-	// WITH options
-	if stmt.WithGrant {
-		parts = append(parts, f.keyword("WITH GRANT OPTION"))
-	}
-	if stmt.WithReplace {
-		parts = append(parts, f.keyword("WITH REPLACE OPTION"))
-	}
-	if stmt.WithAdmin {
-		parts = append(parts, f.keyword("WITH ADMIN OPTION"))
-	}
+		// WITH options
+		if stmt.WithGrant {
+			parts = append(parts, f.keyword("WITH GRANT OPTION"))
+		}
+		if stmt.WithReplace {
+			parts = append(parts, f.keyword("WITH REPLACE OPTION"))
+		}
+		if stmt.WithAdmin {
+			parts = append(parts, f.keyword("WITH ADMIN OPTION"))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // revoke formats a REVOKE statement
 func (f *Formatter) revoke(w io.Writer, stmt *parser.RevokeStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	// REVOKE
-	parts = append(parts, f.keyword("REVOKE"))
+		// REVOKE
+		parts = append(parts, f.keyword("REVOKE"))
 
-	// Options
-	if stmt.GrantOption {
-		parts = append(parts, f.keyword("GRANT OPTION FOR"))
-	}
-	if stmt.AdminOption {
-		parts = append(parts, f.keyword("ADMIN OPTION FOR"))
-	}
+		// Options
+		if stmt.GrantOption {
+			parts = append(parts, f.keyword("GRANT OPTION FOR"))
+		}
+		if stmt.AdminOption {
+			parts = append(parts, f.keyword("ADMIN OPTION FOR"))
+		}
 
-	// Privileges
-	parts = append(parts, f.formatPrivilegeList(stmt.Privileges))
+		// Privileges
+		parts = append(parts, f.formatPrivilegeList(stmt.Privileges))
 
-	// ON CLUSTER
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		// ON CLUSTER
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	// ON target
-	if stmt.On != nil {
-		parts = append(parts, f.keyword("ON"), f.formatGrantTarget(stmt.On))
-	}
+		// ON target
+		if stmt.On != nil {
+			parts = append(parts, f.keyword("ON"), f.formatGrantTarget(stmt.On))
+		}
 
-	// FROM grantees
-	parts = append(parts, f.keyword("FROM"))
-	parts = append(parts, f.formatGranteeList(stmt.From))
+		// FROM grantees
+		parts = append(parts, f.keyword("FROM"))
+		parts = append(parts, f.formatGranteeList(stmt.From))
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // formatRoleSettings formats role settings

--- a/pkg/format/testdata/complex_queries.sql
+++ b/pkg/format/testdata/complex_queries.sql
@@ -1,3 +1,5 @@
+-- Complex SELECT statements
+
 SELECT
     `user_id`,
     toDate(`timestamp`) AS `date`,

--- a/pkg/format/testdata/comprehensive_comments.in.sql
+++ b/pkg/format/testdata/comprehensive_comments.in.sql
@@ -1,0 +1,59 @@
+/*
+* MultiLine Comments are Supported!
+*/
+
+-- housekeeper:import schemas/common.sql
+-- This is a comprehensive test of comment support across all DDL types
+
+-- Create the main database
+CREATE DATABASE analytics ENGINE = Atomic COMMENT 'Analytics database';
+
+-- Create a users table
+-- This table stores user information
+CREATE TABLE analytics.users (
+    id UInt64,
+    name String,
+    email String
+) ENGINE = MergeTree() ORDER BY id;
+
+-- Create a dictionary for user lookups
+-- Uses HTTP source for data
+CREATE DICTIONARY analytics.user_dict (
+    id UInt64,
+    name String
+) PRIMARY KEY id
+SOURCE(HTTP(url 'http://api.example.com/users'))
+LAYOUT(HASHED())
+LIFETIME(3600)
+COMMENT 'User lookup dictionary';
+
+-- Create a materialized view for analytics
+-- Aggregates daily user activity
+CREATE MATERIALIZED VIEW analytics.daily_stats
+ENGINE = MergeTree() ORDER BY date
+AS SELECT toDate(timestamp) as date, count() as users FROM analytics.events GROUP BY date;
+
+-- Create a helper function
+-- Multiplies a number by two
+CREATE FUNCTION double AS (x) -> multiply(x, 2);
+
+-- Attach a backup database
+ATTACH DATABASE backup ENGINE = Memory;
+
+-- Detach temporary database
+DETACH DATABASE temp_db PERMANENTLY;
+
+-- Drop old database
+DROP DATABASE old_analytics SYNC;
+
+-- Rename databases
+RENAME DATABASE staging TO production;
+
+-- Create admin role for database management
+CREATE ROLE db_admin;
+
+-- housekeeper:import some/file.sql
+
+-- Grant privileges to admin role
+-- This allows full database management
+GRANT ALL ON analytics.* TO db_admin WITH GRANT OPTION;

--- a/pkg/format/testdata/comprehensive_comments.sql
+++ b/pkg/format/testdata/comprehensive_comments.sql
@@ -1,0 +1,74 @@
+/*
+* MultiLine Comments are Supported!
+*/
+-- housekeeper:import schemas/common.sql
+-- This is a comprehensive test of comment support across all DDL types
+-- Create the main database
+
+CREATE DATABASE `analytics` ENGINE = Atomic COMMENT 'Analytics database';
+
+-- Create a users table
+-- This table stores user information
+
+CREATE TABLE `analytics`.`users` (
+    `id`    UInt64,
+    `name`  String,
+    `email` String
+)
+ENGINE = MergeTree()
+ORDER BY `id`;
+
+-- Create a dictionary for user lookups
+-- Uses HTTP source for data
+
+CREATE DICTIONARY `analytics`.`user_dict` (
+    `id`   UInt64,
+    `name` String
+)
+PRIMARY KEY `id`
+SOURCE(HTTP(url 'http://api.example.com/users'))
+LAYOUT(HASHED())
+LIFETIME(3600)
+COMMENT 'User lookup dictionary';
+
+-- Create a materialized view for analytics
+-- Aggregates daily user activity
+
+CREATE MATERIALIZED VIEW `analytics`.`daily_stats`
+ENGINE = MergeTree() ORDER BY `date`
+AS SELECT
+    toDate(`timestamp`) AS `date`,
+    count() AS `users`
+FROM `analytics`.`events`
+GROUP BY `date`;
+
+-- Create a helper function
+-- Multiplies a number by two
+
+CREATE FUNCTION `double` AS (`x`) -> multiply(`x`, 2);
+
+-- Attach a backup database
+
+ATTACH DATABASE `backup` ENGINE = Memory;
+
+-- Detach temporary database
+
+DETACH DATABASE `temp_db` PERMANENTLY;
+
+-- Drop old database
+
+DROP DATABASE `old_analytics` SYNC;
+
+-- Rename databases
+
+RENAME DATABASE `staging` TO `production`;
+
+-- Create admin role for database management
+
+CREATE ROLE `db_admin`;
+
+-- housekeeper:import some/file.sql
+-- Grant privileges to admin role
+-- This allows full database management
+
+GRANT ALL ON `analytics`.* TO `db_admin` WITH GRANT OPTION;

--- a/pkg/format/testdata/database_operations.sql
+++ b/pkg/format/testdata/database_operations.sql
@@ -1,3 +1,5 @@
+-- Database operations with various features
+
 CREATE DATABASE `analytics` ENGINE = Atomic COMMENT 'Analytics database';
 
 CREATE DATABASE IF NOT EXISTS `warehouse` ON CLUSTER `production` ENGINE = MaterializedMySQL('localhost:3306', 'warehouse', 'user', 'password') COMMENT 'Data warehouse';

--- a/pkg/format/testdata/database_with_comments.in.sql
+++ b/pkg/format/testdata/database_with_comments.in.sql
@@ -1,0 +1,20 @@
+-- Create the analytics database
+CREATE DATABASE analytics ENGINE = Atomic COMMENT 'Analytics database';
+
+-- Alter the database to update the comment
+ALTER DATABASE analytics MODIFY COMMENT 'Updated analytics database';
+
+-- Attach a database
+-- This is useful for recovery scenarios
+ATTACH DATABASE IF NOT EXISTS backup ENGINE = Memory ON CLUSTER production;
+
+-- Detach the database temporarily  
+DETACH DATABASE IF EXISTS temp_db ON CLUSTER production PERMANENTLY;
+
+-- Drop the old database
+-- Be careful with this operation!
+DROP DATABASE IF EXISTS old_analytics ON CLUSTER production SYNC;
+
+-- Rename databases
+-- This is a batch operation
+RENAME DATABASE staging TO production, test TO staging ON CLUSTER main;

--- a/pkg/format/testdata/database_with_comments.sql
+++ b/pkg/format/testdata/database_with_comments.sql
@@ -1,0 +1,26 @@
+-- Create the analytics database
+
+CREATE DATABASE `analytics` ENGINE = Atomic COMMENT 'Analytics database';
+
+-- Alter the database to update the comment
+
+ALTER DATABASE `analytics` MODIFY COMMENT 'Updated analytics database';
+
+-- Attach a database
+-- This is useful for recovery scenarios
+
+ATTACH DATABASE IF NOT EXISTS `backup` ENGINE = Memory ON CLUSTER `production`;
+
+-- Detach the database temporarily  
+
+DETACH DATABASE IF EXISTS `temp_db` ON CLUSTER `production` PERMANENTLY;
+
+-- Drop the old database
+-- Be careful with this operation!
+
+DROP DATABASE IF EXISTS `old_analytics` ON CLUSTER `production` SYNC;
+
+-- Rename databases
+-- This is a batch operation
+
+RENAME DATABASE `staging` TO `production`, `test` TO `staging` ON CLUSTER `main`;

--- a/pkg/format/testdata/dictionary_operations.sql
+++ b/pkg/format/testdata/dictionary_operations.sql
@@ -1,3 +1,5 @@
+-- Dictionary operations with complex configurations
+
 CREATE DICTIONARY `analytics`.`users_dict` (
     `id`         UInt64 IS_OBJECT_ID,
     `name`       String INJECTIVE,

--- a/pkg/format/testdata/mixed_operations.sql
+++ b/pkg/format/testdata/mixed_operations.sql
@@ -1,3 +1,5 @@
+-- Mixed DDL operations
+
 CREATE DATABASE `analytics` ENGINE = Atomic;
 
 CREATE TABLE `analytics`.`raw_events` (

--- a/pkg/format/testdata/named_collection_operations.sql
+++ b/pkg/format/testdata/named_collection_operations.sql
@@ -1,3 +1,5 @@
+-- Named collection operations
+
 CREATE NAMED COLLECTION `my_s3_collection` AS
     `access_key_id` = 'AKIAIOSFODNN7EXAMPLE',
     `secret_access_key` = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',

--- a/pkg/format/testdata/role_grant_comments.in.sql
+++ b/pkg/format/testdata/role_grant_comments.in.sql
@@ -1,0 +1,21 @@
+-- Role and permission management
+
+-- Create admin role
+CREATE ROLE admin;
+
+-- Create read-only role
+-- This role has limited permissions
+CREATE ROLE readonly SETTINGS readonly = 1;
+
+-- Grant SELECT to readonly
+-- Allow reading from analytics database
+GRANT SELECT ON analytics.* TO readonly;
+
+-- Grant all privileges to admin
+GRANT ALL ON *.* TO admin WITH GRANT OPTION;
+
+-- Revoke DELETE from readonly
+REVOKE DELETE ON analytics.users FROM readonly;
+
+-- Drop old role
+DROP ROLE IF EXISTS deprecated_role;

--- a/pkg/format/testdata/role_grant_comments.sql
+++ b/pkg/format/testdata/role_grant_comments.sql
@@ -1,0 +1,26 @@
+-- Role and permission management
+-- Create admin role
+
+CREATE ROLE `admin`;
+
+-- Create read-only role
+-- This role has limited permissions
+
+CREATE ROLE `readonly` SETTINGS `readonly` = 1;
+
+-- Grant SELECT to readonly
+-- Allow reading from analytics database
+
+GRANT `SELECT` ON `analytics`.* TO `readonly`;
+
+-- Grant all privileges to admin
+
+GRANT ALL ON *.* TO `admin` WITH GRANT OPTION;
+
+-- Revoke DELETE from readonly
+
+REVOKE `DELETE` ON `analytics`.`users` FROM `readonly`;
+
+-- Drop old role
+
+DROP ROLE IF EXISTS `deprecated_role`;

--- a/pkg/format/testdata/table_operations.sql
+++ b/pkg/format/testdata/table_operations.sql
@@ -1,3 +1,5 @@
+-- Table operations with complex features
+
 CREATE TABLE `analytics`.`events` (
     `id`         UInt64,
     `user_id`    UInt64,

--- a/pkg/format/testdata/view_operations.sql
+++ b/pkg/format/testdata/view_operations.sql
@@ -1,3 +1,5 @@
+-- View operations with SELECT statements
+
 CREATE VIEW `analytics`.`daily_summary`
 AS SELECT
     toDate(`timestamp`) AS `date`,

--- a/pkg/format/view.go
+++ b/pkg/format/view.go
@@ -9,134 +9,142 @@ import (
 
 // CreateView formats a CREATE VIEW statement (both regular and materialized)
 func (f *Formatter) createView(w io.Writer, stmt *parser.CreateViewStmt) error {
-	var lines []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var lines []string
 
-	// Build the header line
-	var headerParts []string
-	headerParts = append(headerParts, f.keyword("CREATE"))
+		// Build the header line
+		var headerParts []string
+		headerParts = append(headerParts, f.keyword("CREATE"))
 
-	if stmt.OrReplace {
-		headerParts = append(headerParts, f.keyword("OR REPLACE"))
-	}
-
-	if stmt.Materialized {
-		headerParts = append(headerParts, f.keyword("MATERIALIZED"))
-	}
-
-	headerParts = append(headerParts, f.keyword("VIEW"))
-
-	if stmt.IfNotExists {
-		headerParts = append(headerParts, f.keyword("IF NOT EXISTS"))
-	}
-
-	headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
-
-	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
-
-	lines = append(lines, strings.Join(headerParts, " "))
-
-	// TO table (for materialized views)
-	if stmt.To != nil {
-		// Parse the TO table name to handle database.table format
-		parts := strings.Split(*stmt.To, ".")
-		if len(parts) == 2 {
-			lines = append(lines, f.keyword("TO")+" "+f.qualifiedName(&parts[0], parts[1]))
-		} else {
-			lines = append(lines, f.keyword("TO")+" "+f.identifier(*stmt.To))
+		if stmt.OrReplace {
+			headerParts = append(headerParts, f.keyword("OR REPLACE"))
 		}
-	}
 
-	// ENGINE (for materialized views)
-	if stmt.Engine != nil {
-		lines = append(lines, f.formatViewEngine(stmt.Engine))
-	}
+		if stmt.Materialized {
+			headerParts = append(headerParts, f.keyword("MATERIALIZED"))
+		}
 
-	// POPULATE (for materialized views)
-	if stmt.Populate {
-		lines = append(lines, f.keyword("POPULATE"))
-	}
+		headerParts = append(headerParts, f.keyword("VIEW"))
 
-	// AS SELECT
-	if stmt.AsSelect != nil {
-		lines = append(lines, f.keyword("AS")+" "+f.formatSelectStatement(stmt.AsSelect))
-	}
+		if stmt.IfNotExists {
+			headerParts = append(headerParts, f.keyword("IF NOT EXISTS"))
+		}
 
-	_, err := w.Write([]byte(strings.Join(lines, "\n") + ";"))
-	return err
+		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
+
+		if stmt.OnCluster != nil {
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
+
+		lines = append(lines, strings.Join(headerParts, " "))
+
+		// TO table (for materialized views)
+		if stmt.To != nil {
+			// Parse the TO table name to handle database.table format
+			parts := strings.Split(*stmt.To, ".")
+			if len(parts) == 2 {
+				lines = append(lines, f.keyword("TO")+" "+f.qualifiedName(&parts[0], parts[1]))
+			} else {
+				lines = append(lines, f.keyword("TO")+" "+f.identifier(*stmt.To))
+			}
+		}
+
+		// ENGINE (for materialized views)
+		if stmt.Engine != nil {
+			lines = append(lines, f.formatViewEngine(stmt.Engine))
+		}
+
+		// POPULATE (for materialized views)
+		if stmt.Populate {
+			lines = append(lines, f.keyword("POPULATE"))
+		}
+
+		// AS SELECT
+		if stmt.AsSelect != nil {
+			lines = append(lines, f.keyword("AS")+" "+f.formatSelectStatement(stmt.AsSelect))
+		}
+
+		_, err := w.Write([]byte(strings.Join(lines, "\n") + ";"))
+		return err
+	})
 }
 
 // AttachView formats an ATTACH VIEW statement
 func (f *Formatter) attachView(w io.Writer, stmt *parser.AttachViewStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	parts = append(parts, f.keyword("ATTACH VIEW"))
+		parts = append(parts, f.keyword("ATTACH VIEW"))
 
-	if stmt.IfNotExists {
-		parts = append(parts, f.keyword("IF NOT EXISTS"))
-	}
+		if stmt.IfNotExists {
+			parts = append(parts, f.keyword("IF NOT EXISTS"))
+		}
 
-	parts = append(parts, f.qualifiedName(stmt.Database, stmt.Name))
+		parts = append(parts, f.qualifiedName(stmt.Database, stmt.Name))
 
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // DetachView formats a DETACH VIEW statement
 func (f *Formatter) detachView(w io.Writer, stmt *parser.DetachViewStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	parts = append(parts, f.keyword("DETACH VIEW"))
+		parts = append(parts, f.keyword("DETACH VIEW"))
 
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("IF EXISTS"))
-	}
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("IF EXISTS"))
+		}
 
-	parts = append(parts, f.qualifiedName(stmt.Database, stmt.Name))
+		parts = append(parts, f.qualifiedName(stmt.Database, stmt.Name))
 
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	if stmt.Permanently {
-		parts = append(parts, f.keyword("PERMANENTLY"))
-	}
+		if stmt.Permanently {
+			parts = append(parts, f.keyword("PERMANENTLY"))
+		}
 
-	if stmt.Sync {
-		parts = append(parts, f.keyword("SYNC"))
-	}
+		if stmt.Sync {
+			parts = append(parts, f.keyword("SYNC"))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // DropView formats a DROP VIEW statement
 func (f *Formatter) dropView(w io.Writer, stmt *parser.DropViewStmt) error {
-	var parts []string
+	return f.formatWithComments(w, stmt, func(w io.Writer) error {
+		var parts []string
 
-	parts = append(parts, f.keyword("DROP VIEW"))
+		parts = append(parts, f.keyword("DROP VIEW"))
 
-	if stmt.IfExists {
-		parts = append(parts, f.keyword("IF EXISTS"))
-	}
+		if stmt.IfExists {
+			parts = append(parts, f.keyword("IF EXISTS"))
+		}
 
-	parts = append(parts, f.qualifiedName(stmt.Database, stmt.Name))
+		parts = append(parts, f.qualifiedName(stmt.Database, stmt.Name))
 
-	if stmt.OnCluster != nil {
-		parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
-	}
+		if stmt.OnCluster != nil {
+			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		}
 
-	if stmt.Sync {
-		parts = append(parts, f.keyword("SYNC"))
-	}
+		if stmt.Sync {
+			parts = append(parts, f.keyword("SYNC"))
+		}
 
-	_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
-	return err
+		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))
+		return err
+	})
 }
 
 // formatViewEngine formats a materialized view ENGINE clause with optional DDL

--- a/pkg/migrator/migration_test.go
+++ b/pkg/migrator/migration_test.go
@@ -49,16 +49,16 @@ func TestLoadMigration(t *testing.T) {
 			name:    "complex_migration",
 			version: "003_complex_schema",
 			sql: `CREATE DATABASE analytics ENGINE = Atomic;
-				  
+
 				  CREATE TABLE analytics.users (
 					  id UInt64,
 					  email String,
 					  created_at DateTime DEFAULT now(),
 					  metadata Map(String, String) DEFAULT map()
-				  ) ENGINE = MergeTree() 
+				  ) ENGINE = MergeTree()
 				  ORDER BY (id, created_at)
 				  PARTITION BY toYYYYMM(created_at);
-				  
+
 				  CREATE DICTIONARY analytics.user_dict (
 					  id UInt64 IS_OBJECT_ID,
 					  email String INJECTIVE
@@ -66,7 +66,7 @@ func TestLoadMigration(t *testing.T) {
 				  SOURCE(HTTP(url 'http://api.example.com/users'))
 				  LAYOUT(HASHED())
 				  LIFETIME(3600);
-				  
+
 				  CREATE MATERIALIZED VIEW analytics.daily_stats
 				  ENGINE = MergeTree() ORDER BY date
 				  AS SELECT toDate(created_at), count()
@@ -88,7 +88,7 @@ func TestLoadMigration(t *testing.T) {
 			version:     "005_comments",
 			sql:         "-- This is a comment\n/* Multi-line comment */",
 			wantErr:     false,
-			stmtCount:   0,
+			stmtCount:   2,
 			description: "Migration with only comments should parse successfully",
 		},
 		{
@@ -791,8 +791,8 @@ func TestMigrationDir_Validate_ComplexMigrations(t *testing.T) {
 			timestamp DateTime DEFAULT now(),
 			data Map(String, String) DEFAULT map(),
 			metadata Nullable(String)
-		) ENGINE = MergeTree() 
-		ORDER BY (id, timestamp) 
+		) ENGINE = MergeTree()
+		ORDER BY (id, timestamp)
 		PARTITION BY toYYYYMM(timestamp);`,
 		"20240101120200.sql": `CREATE MATERIALIZED VIEW analytics.daily_stats
 		ENGINE = MergeTree() ORDER BY date

--- a/pkg/parser/column.go
+++ b/pkg/parser/column.go
@@ -6,9 +6,11 @@ type (
 	// such as DEFAULT values, MATERIALIZED expressions, ALIAS definitions,
 	// compression CODECs, TTL settings, and comments.
 	Column struct {
-		Name       string            `parser:"@(Ident | BacktickIdent)"`
-		DataType   *DataType         `parser:"@@"`
-		Attributes []ColumnAttribute `parser:"@@*"`
+		LeadingComments  []string          `parser:"@(Comment | MultilineComment)*"`
+		Name             string            `parser:"@(Ident | BacktickIdent)"`
+		DataType         *DataType         `parser:"@@"`
+		Attributes       []ColumnAttribute `parser:"@@*"`
+		TrailingComments []string          `parser:"@(Comment | MultilineComment)*"`
 	}
 
 	// ColumnAttribute represents any attribute that can appear after the data type

--- a/pkg/parser/database.go
+++ b/pkg/parser/database.go
@@ -4,12 +4,16 @@ type (
 	// CreateDatabaseStmt represents CREATE DATABASE statements
 	// Syntax: CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster] [ENGINE = engine(...)] [COMMENT 'Comment'];
 	CreateDatabaseStmt struct {
-		IfNotExists bool            `parser:"'CREATE' 'DATABASE' @('IF' 'NOT' 'EXISTS')?"`
-		Name        string          `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Engine      *DatabaseEngine `parser:"@@?"`
-		Comment     *string         `parser:"('COMMENT' @String)?"`
-		Semicolon   bool            `parser:"';'"`
+		LeadingComments  []string        `parser:"@(Comment | MultilineComment)*"`
+		Create           string          `parser:"'CREATE'"`
+		Database         string          `parser:"'DATABASE'"`
+		IfNotExists      bool            `parser:"@('IF' 'NOT' 'EXISTS')?"`
+		Name             string          `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Engine           *DatabaseEngine `parser:"@@?"`
+		Comment          *string         `parser:"('COMMENT' @String)?"`
+		TrailingComments []string        `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool            `parser:"';'"`
 	}
 
 	// DatabaseEngine represents ENGINE = clause for databases
@@ -26,10 +30,14 @@ type (
 	// AlterDatabaseStmt represents ALTER DATABASE statements
 	// Syntax: ALTER DATABASE [db].name [ON CLUSTER cluster] MODIFY COMMENT 'Comment';
 	AlterDatabaseStmt struct {
-		Name      string               `parser:"'ALTER' 'DATABASE' @(Ident | BacktickIdent)"`
-		OnCluster *string              `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Action    *AlterDatabaseAction `parser:"@@"`
-		Semicolon bool                 `parser:"';'"`
+		LeadingComments  []string             `parser:"@(Comment | MultilineComment)*"`
+		Alter            string               `parser:"'ALTER'"`
+		Database         string               `parser:"'DATABASE'"`
+		Name             string               `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string              `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Action           *AlterDatabaseAction `parser:"@@"`
+		TrailingComments []string             `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool                 `parser:"';'"`
 	}
 
 	// AlterDatabaseAction represents the action to perform on the database
@@ -40,40 +48,56 @@ type (
 	// AttachDatabaseStmt represents ATTACH DATABASE statements
 	// Syntax: ATTACH DATABASE [IF NOT EXISTS] name [ENGINE = engine(...)] [ON CLUSTER cluster];
 	AttachDatabaseStmt struct {
-		IfNotExists bool            `parser:"'ATTACH' 'DATABASE' @('IF' 'NOT' 'EXISTS')?"`
-		Name        string          `parser:"@(Ident | BacktickIdent)"`
-		Engine      *DatabaseEngine `parser:"@@?"`
-		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon   bool            `parser:"';'"`
+		LeadingComments  []string        `parser:"@(Comment | MultilineComment)*"`
+		Attach           string          `parser:"'ATTACH'"`
+		Database         string          `parser:"'DATABASE'"`
+		IfNotExists      bool            `parser:"@('IF' 'NOT' 'EXISTS')?"`
+		Name             string          `parser:"@(Ident | BacktickIdent)"`
+		Engine           *DatabaseEngine `parser:"@@?"`
+		OnCluster        *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string        `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool            `parser:"';'"`
 	}
 
 	// DetachDatabaseStmt represents DETACH DATABASE statements
 	// Syntax: DETACH DATABASE [IF EXISTS] [db.]name [ON CLUSTER cluster] [PERMANENTLY] [SYNC];
 	DetachDatabaseStmt struct {
-		IfExists    bool    `parser:"'DETACH' 'DATABASE' @('IF' 'EXISTS')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Permanently bool    `parser:"@'PERMANENTLY'?"`
-		Sync        bool    `parser:"@'SYNC'?"`
-		Semicolon   bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Detach           string   `parser:"'DETACH'"`
+		Database         string   `parser:"'DATABASE'"`
+		IfExists         bool     `parser:"@('IF' 'EXISTS')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Permanently      bool     `parser:"@'PERMANENTLY'?"`
+		Sync             bool     `parser:"@'SYNC'?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// DropDatabaseStmt represents DROP DATABASE statements
 	// Syntax: DROP DATABASE [IF EXISTS] db [ON CLUSTER cluster] [SYNC];
 	DropDatabaseStmt struct {
-		IfExists  bool    `parser:"'DROP' 'DATABASE' @('IF' 'EXISTS')?"`
-		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Sync      bool    `parser:"@'SYNC'?"`
-		Semicolon bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Drop             string   `parser:"'DROP'"`
+		Database         string   `parser:"'DATABASE'"`
+		IfExists         bool     `parser:"@('IF' 'EXISTS')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Sync             bool     `parser:"@'SYNC'?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// RenameDatabaseStmt represents RENAME DATABASE statements
 	// Syntax: RENAME DATABASE name1 TO new_name1 [, name2 TO new_name2, ...] [ON CLUSTER cluster];
 	RenameDatabaseStmt struct {
-		Renames   []*DatabaseRename `parser:"'RENAME' 'DATABASE' @@ (',' @@)*"`
-		OnCluster *string           `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon bool              `parser:"';'"`
+		LeadingComments  []string          `parser:"@(Comment | MultilineComment)*"`
+		Rename           string            `parser:"'RENAME'"`
+		Database         string            `parser:"'DATABASE'"`
+		Renames          []*DatabaseRename `parser:"@@ (',' @@)*"`
+		OnCluster        *string           `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string          `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool              `parser:"';'"`
 	}
 
 	// DatabaseRename represents a single database rename operation
@@ -82,3 +106,63 @@ type (
 		To   string `parser:"'TO' @(Ident | BacktickIdent)"`
 	}
 )
+
+// GetLeadingComments returns the leading comments for CreateDatabaseStmt
+func (s *CreateDatabaseStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for CreateDatabaseStmt
+func (s *CreateDatabaseStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AlterDatabaseStmt
+func (s *AlterDatabaseStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AlterDatabaseStmt
+func (s *AlterDatabaseStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AttachDatabaseStmt
+func (s *AttachDatabaseStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AttachDatabaseStmt
+func (s *AttachDatabaseStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DetachDatabaseStmt
+func (s *DetachDatabaseStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DetachDatabaseStmt
+func (s *DetachDatabaseStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DropDatabaseStmt
+func (s *DropDatabaseStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DropDatabaseStmt
+func (s *DropDatabaseStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for RenameDatabaseStmt
+func (s *RenameDatabaseStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for RenameDatabaseStmt
+func (s *RenameDatabaseStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}

--- a/pkg/parser/dictionary.go
+++ b/pkg/parser/dictionary.go
@@ -18,16 +18,18 @@ type (
 	//   [SETTINGS(setting1 = value1 [, setting2 = value2, ...])]
 	//   [COMMENT 'comment']
 	CreateDictionaryStmt struct {
-		Create      string              `parser:"'CREATE'"`
-		OrReplace   bool                `parser:"@('OR' 'REPLACE')?"`
-		Dictionary  string              `parser:"'DICTIONARY'"`
-		IfNotExists *string             `parser:"(@'IF' 'NOT' 'EXISTS')?"`
-		Database    *string             `parser:"((@(Ident | BacktickIdent) '.')?"`
-		Name        string              `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Columns     []*DictionaryColumn `parser:"'(' @@* ')'"`
-		Clauses     []DictionaryClause  `parser:"@@*"`
-		Comment     *string             `parser:"('COMMENT' @String)? ';'"`
+		LeadingComments  []string            `parser:"@(Comment | MultilineComment)*"`
+		Create           string              `parser:"'CREATE'"`
+		OrReplace        bool                `parser:"@('OR' 'REPLACE')?"`
+		Dictionary       string              `parser:"'DICTIONARY'"`
+		IfNotExists      *string             `parser:"(@'IF' 'NOT' 'EXISTS')?"`
+		Database         *string             `parser:"((@(Ident | BacktickIdent) '.')?"`
+		Name             string              `parser:"@(Ident | BacktickIdent))"`
+		OnCluster        *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Columns          []*DictionaryColumn `parser:"'(' @@* ')'"`
+		Clauses          []DictionaryClause  `parser:"@@*"`
+		Comment          *string             `parser:"('COMMENT' @String)?"`
+		TrailingComments []string            `parser:"@(Comment | MultilineComment)* ';'"`
 	}
 
 	// DictionaryClause represents any clause that can appear after columns in a CREATE DICTIONARY statement
@@ -150,40 +152,48 @@ type (
 	// ClickHouse syntax:
 	//   ATTACH DICTIONARY [IF NOT EXISTS] [db.]dict_name [ON CLUSTER cluster]
 	AttachDictionaryStmt struct {
-		IfNotExists *string `parser:"'ATTACH' 'DICTIONARY' (@'IF' 'NOT' 'EXISTS')?"`
-		Database    *string `parser:"((@(Ident | BacktickIdent) '.')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))? ';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		IfNotExists      *string  `parser:"'ATTACH' 'DICTIONARY' (@'IF' 'NOT' 'EXISTS')?"`
+		Database         *string  `parser:"((@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent))"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)* ';'"`
 	}
 
 	// DetachDictionaryStmt represents DETACH DICTIONARY statements.
 	// ClickHouse syntax:
 	//   DETACH DICTIONARY [IF EXISTS] [db.]dict_name [ON CLUSTER cluster] [PERMANENTLY] [SYNC]
 	DetachDictionaryStmt struct {
-		IfExists    *string `parser:"'DETACH' 'DICTIONARY' (@'IF' 'EXISTS')?"`
-		Database    *string `parser:"((@(Ident | BacktickIdent) '.')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Permanently *string `parser:"(@'PERMANENTLY')?"`
-		Sync        *string `parser:"(@'SYNC')? ';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		IfExists         *string  `parser:"'DETACH' 'DICTIONARY' (@'IF' 'EXISTS')?"`
+		Database         *string  `parser:"((@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent))"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Permanently      *string  `parser:"(@'PERMANENTLY')?"`
+		Sync             *string  `parser:"(@'SYNC')?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)* ';'"`
 	}
 
 	// DropDictionaryStmt represents DROP DICTIONARY statements.
 	// ClickHouse syntax:
 	//   DROP DICTIONARY [IF EXISTS] [db.]dict_name [ON CLUSTER cluster] [SYNC]
 	DropDictionaryStmt struct {
-		IfExists  *string `parser:"'DROP' 'DICTIONARY' (@'IF' 'EXISTS')?"`
-		Database  *string `parser:"((@(Ident | BacktickIdent) '.')?"`
-		Name      string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Sync      *string `parser:"(@'SYNC')? ';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		IfExists         *string  `parser:"'DROP' 'DICTIONARY' (@'IF' 'EXISTS')?"`
+		Database         *string  `parser:"((@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent))"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Sync             *string  `parser:"(@'SYNC')?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)* ';'"`
 	}
 
 	// RenameDictionaryStmt represents RENAME DICTIONARY statements
 	// Syntax: RENAME DICTIONARY [db.]name1 TO [db.]new_name1 [, [db.]name2 TO [db.]new_name2, ...] [ON CLUSTER cluster];
 	RenameDictionaryStmt struct {
-		Renames   []*DictionaryRename `parser:"'RENAME' 'DICTIONARY' @@ (',' @@)*"`
-		OnCluster *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))? ';'"`
+		LeadingComments  []string            `parser:"@(Comment | MultilineComment)*"`
+		Renames          []*DictionaryRename `parser:"'RENAME' 'DICTIONARY' @@ (',' @@)*"`
+		OnCluster        *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string            `parser:"@(Comment | MultilineComment)* ';'"`
 	}
 
 	// DictionaryRename represents a single dictionary rename operation
@@ -290,4 +300,54 @@ func (c *CreateDictionaryStmt) GetSettings() *DictionarySettings {
 		}
 	}
 	return nil
+}
+
+// GetLeadingComments returns the leading comments for CreateDictionaryStmt
+func (c *CreateDictionaryStmt) GetLeadingComments() []string {
+	return c.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for CreateDictionaryStmt
+func (c *CreateDictionaryStmt) GetTrailingComments() []string {
+	return c.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AttachDictionaryStmt
+func (a *AttachDictionaryStmt) GetLeadingComments() []string {
+	return a.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AttachDictionaryStmt
+func (a *AttachDictionaryStmt) GetTrailingComments() []string {
+	return a.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DetachDictionaryStmt
+func (d *DetachDictionaryStmt) GetLeadingComments() []string {
+	return d.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DetachDictionaryStmt
+func (d *DetachDictionaryStmt) GetTrailingComments() []string {
+	return d.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DropDictionaryStmt
+func (d *DropDictionaryStmt) GetLeadingComments() []string {
+	return d.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DropDictionaryStmt
+func (d *DropDictionaryStmt) GetTrailingComments() []string {
+	return d.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for RenameDictionaryStmt
+func (r *RenameDictionaryStmt) GetLeadingComments() []string {
+	return r.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for RenameDictionaryStmt
+func (r *RenameDictionaryStmt) GetTrailingComments() []string {
+	return r.TrailingComments
 }

--- a/pkg/parser/function.go
+++ b/pkg/parser/function.go
@@ -4,20 +4,24 @@ type (
 	// CreateFunctionStmt represents CREATE FUNCTION statements
 	// Syntax: CREATE FUNCTION name [ON CLUSTER cluster] AS (parameter0, ...) -> expression;
 	CreateFunctionStmt struct {
-		Name       string           `parser:"'CREATE' 'FUNCTION' @(Ident | BacktickIdent)"`
-		OnCluster  *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Parameters []*FunctionParam `parser:"'AS' '(' (@@ (',' @@)*)? ')'"`
-		Expression *Expression      `parser:"'->' @@"`
-		Semicolon  bool             `parser:"';'"`
+		LeadingComments  []string         `parser:"@(Comment | MultilineComment)*"`
+		Name             string           `parser:"'CREATE' 'FUNCTION' @(Ident | BacktickIdent)"`
+		OnCluster        *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Parameters       []*FunctionParam `parser:"'AS' '(' (@@ (',' @@)*)? ')'"`
+		Expression       *Expression      `parser:"'->' @@"`
+		TrailingComments []string         `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool             `parser:"';'"`
 	}
 
 	// DropFunctionStmt represents DROP FUNCTION statements
 	// Syntax: DROP FUNCTION [IF EXISTS] name [ON CLUSTER cluster];
 	DropFunctionStmt struct {
-		IfExists  bool    `parser:"'DROP' 'FUNCTION' @('IF' 'EXISTS')?"`
-		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		IfExists         bool     `parser:"'DROP' 'FUNCTION' @('IF' 'EXISTS')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// FunctionParam represents a function parameter
@@ -26,3 +30,23 @@ type (
 		Name string `parser:"@(Ident | BacktickIdent)"`
 	}
 )
+
+// GetLeadingComments returns the leading comments for CreateFunctionStmt
+func (c *CreateFunctionStmt) GetLeadingComments() []string {
+	return c.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for CreateFunctionStmt
+func (c *CreateFunctionStmt) GetTrailingComments() []string {
+	return c.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DropFunctionStmt
+func (d *DropFunctionStmt) GetLeadingComments() []string {
+	return d.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DropFunctionStmt
+func (d *DropFunctionStmt) GetTrailingComments() []string {
+	return d.TrailingComments
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -30,7 +30,7 @@ var (
 	// parser is the participle parser instance for ClickHouse DDL
 	parser = participle.MustBuild[SQL](
 		participle.Lexer(clickhouseLexer),
-		participle.Elide("Comment", "MultilineComment", "Whitespace"),
+		participle.Elide("Whitespace"), // Only elide whitespace, capture comments
 		participle.UseLookahead(4),
 		participle.CaseInsensitive("Ident"), // Make identifier matching case-insensitive for keywords
 	)
@@ -111,7 +111,8 @@ type (
 
 	// Statement represents any DDL or DML statement
 	Statement struct {
-		CreateDatabase        *CreateDatabaseStmt        `parser:"@@"`
+		CommentStatement      *CommentStatement          `parser:"@@"`
+		CreateDatabase        *CreateDatabaseStmt        `parser:"| @@"`
 		AlterDatabase         *AlterDatabaseStmt         `parser:"| @@"`
 		AttachDatabase        *AttachDatabaseStmt        `parser:"| @@"`
 		DetachDatabase        *DetachDatabaseStmt        `parser:"| @@"`
@@ -145,6 +146,11 @@ type (
 		RenameTable           *RenameTableStmt           `parser:"| @@"`
 		RenameDictionary      *RenameDictionaryStmt      `parser:"| @@"`
 		SelectStatement       *TopLevelSelectStatement   `parser:"| @@"`
+	}
+
+	// CommentStatement represents a standalone comment line (file-level comments, imports, etc.)
+	CommentStatement struct {
+		Comment string `parser:"@(Comment | MultilineComment)"`
 	}
 )
 

--- a/pkg/parser/role.go
+++ b/pkg/parser/role.go
@@ -4,32 +4,38 @@ type (
 	// CreateRoleStmt represents CREATE ROLE statements
 	// Syntax: CREATE ROLE [IF NOT EXISTS | OR REPLACE] name [ON CLUSTER cluster] [SETTINGS ...];
 	CreateRoleStmt struct {
-		OrReplace   bool          `parser:"'CREATE' (@'OR' 'REPLACE')? 'ROLE'"`
-		IfNotExists bool          `parser:"@('IF' 'NOT' 'EXISTS')?"`
-		Name        string        `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Settings    *RoleSettings `parser:"@@?"`
-		Semicolon   bool          `parser:"@';'"`
+		LeadingComments  []string      `parser:"@(Comment | MultilineComment)*"`
+		OrReplace        bool          `parser:"'CREATE' (@'OR' 'REPLACE')? 'ROLE'"`
+		IfNotExists      bool          `parser:"@('IF' 'NOT' 'EXISTS')?"`
+		Name             string        `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Settings         *RoleSettings `parser:"@@?"`
+		TrailingComments []string      `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool          `parser:"@';'"`
 	}
 
 	// AlterRoleStmt represents ALTER ROLE statements
 	// Syntax: ALTER ROLE [IF EXISTS] name [ON CLUSTER cluster] [RENAME TO new_name] [SETTINGS ...];
 	AlterRoleStmt struct {
-		IfExists  bool          `parser:"'ALTER' 'ROLE' @('IF' 'EXISTS')?"`
-		Name      string        `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		RenameTo  *string       `parser:"('RENAME' 'TO' @(Ident | BacktickIdent))?"`
-		Settings  *RoleSettings `parser:"@@?"`
-		Semicolon bool          `parser:"@';'"`
+		LeadingComments  []string      `parser:"@(Comment | MultilineComment)*"`
+		IfExists         bool          `parser:"'ALTER' 'ROLE' @('IF' 'EXISTS')?"`
+		Name             string        `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		RenameTo         *string       `parser:"('RENAME' 'TO' @(Ident | BacktickIdent))?"`
+		Settings         *RoleSettings `parser:"@@?"`
+		TrailingComments []string      `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool          `parser:"@';'"`
 	}
 
 	// DropRoleStmt represents DROP ROLE statements
 	// Syntax: DROP ROLE [IF EXISTS] name [,...] [ON CLUSTER cluster];
 	DropRoleStmt struct {
-		IfExists  bool     `parser:"'DROP' 'ROLE' @('IF' 'EXISTS')?"`
-		Names     []string `parser:"@(Ident | BacktickIdent) (',' @(Ident | BacktickIdent))*"`
-		OnCluster *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon bool     `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		IfExists         bool     `parser:"'DROP' 'ROLE' @('IF' 'EXISTS')?"`
+		Names            []string `parser:"@(Ident | BacktickIdent) (',' @(Ident | BacktickIdent))*"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// SetRoleStmt represents SET ROLE statements for session management
@@ -57,26 +63,30 @@ type (
 	// GrantStmt represents GRANT statements
 	// Syntax: GRANT {privilege | role} [,...] [ON {database.table | *.*}] TO {user | role} [,...] [WITH GRANT OPTION];
 	GrantStmt struct {
-		Privileges  *PrivilegeList `parser:"'GRANT' @@"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		On          *GrantTarget   `parser:"('ON' @@)?"`
-		To          *GranteeList   `parser:"'TO' @@"`
-		WithGrant   bool           `parser:"@('WITH' 'GRANT' 'OPTION')?"`
-		WithReplace bool           `parser:"@('WITH' 'REPLACE' 'OPTION')?"`
-		WithAdmin   bool           `parser:"@('WITH' 'ADMIN' 'OPTION')?"`
-		Semicolon   bool           `parser:"';'"`
+		LeadingComments  []string       `parser:"@(Comment | MultilineComment)*"`
+		Privileges       *PrivilegeList `parser:"'GRANT' @@"`
+		OnCluster        *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		On               *GrantTarget   `parser:"('ON' @@)?"`
+		To               *GranteeList   `parser:"'TO' @@"`
+		WithGrant        bool           `parser:"@('WITH' 'GRANT' 'OPTION')?"`
+		WithReplace      bool           `parser:"@('WITH' 'REPLACE' 'OPTION')?"`
+		WithAdmin        bool           `parser:"@('WITH' 'ADMIN' 'OPTION')?"`
+		TrailingComments []string       `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool           `parser:"';'"`
 	}
 
 	// RevokeStmt represents REVOKE statements
 	// Syntax: REVOKE [GRANT OPTION FOR | ADMIN OPTION FOR] {privilege | role} [,...] [ON {database.table | *.*}] FROM {user | role} [,...];
 	RevokeStmt struct {
-		GrantOption bool           `parser:"'REVOKE' (@'GRANT' 'OPTION' 'FOR'"`
-		AdminOption bool           `parser:"| @'ADMIN' 'OPTION' 'FOR')?"`
-		Privileges  *PrivilegeList `parser:"@@"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		On          *GrantTarget   `parser:"('ON' @@)?"`
-		From        *GranteeList   `parser:"'FROM' @@"`
-		Semicolon   bool           `parser:"@';'"`
+		LeadingComments  []string       `parser:"@(Comment | MultilineComment)*"`
+		GrantOption      bool           `parser:"'REVOKE' (@'GRANT' 'OPTION' 'FOR'"`
+		AdminOption      bool           `parser:"| @'ADMIN' 'OPTION' 'FOR')?"`
+		Privileges       *PrivilegeList `parser:"@@"`
+		OnCluster        *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		On               *GrantTarget   `parser:"('ON' @@)?"`
+		From             *GranteeList   `parser:"'FROM' @@"`
+		TrailingComments []string       `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool           `parser:"@';'"`
 	}
 
 	// RoleSettings represents SETTINGS clause for roles
@@ -128,3 +138,53 @@ type (
 		IsCurrent bool   `parser:"| @'CURRENT_USER'"`
 	}
 )
+
+// GetLeadingComments returns the leading comments for CreateRoleStmt
+func (c *CreateRoleStmt) GetLeadingComments() []string {
+	return c.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for CreateRoleStmt
+func (c *CreateRoleStmt) GetTrailingComments() []string {
+	return c.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AlterRoleStmt
+func (a *AlterRoleStmt) GetLeadingComments() []string {
+	return a.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AlterRoleStmt
+func (a *AlterRoleStmt) GetTrailingComments() []string {
+	return a.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DropRoleStmt
+func (d *DropRoleStmt) GetLeadingComments() []string {
+	return d.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DropRoleStmt
+func (d *DropRoleStmt) GetTrailingComments() []string {
+	return d.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for GrantStmt
+func (g *GrantStmt) GetLeadingComments() []string {
+	return g.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for GrantStmt
+func (g *GrantStmt) GetTrailingComments() []string {
+	return g.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for RevokeStmt
+func (r *RevokeStmt) GetLeadingComments() []string {
+	return r.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for RevokeStmt
+func (r *RevokeStmt) GetTrailingComments() []string {
+	return r.TrailingComments
+}

--- a/pkg/parser/table.go
+++ b/pkg/parser/table.go
@@ -21,29 +21,34 @@ type (
 	//   [SETTINGS name=value, ...]
 	//   [COMMENT 'comment']
 	CreateTableStmt struct {
-		Create      string         `parser:"'CREATE'"`
-		OrReplace   bool           `parser:"@('OR' 'REPLACE')?"`
-		Table       string         `parser:"'TABLE'"`
-		IfNotExists bool           `parser:"@('IF' 'NOT' 'EXISTS')?"`
-		Database    *string        `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name        string         `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Elements    []TableElement `parser:"'(' @@ (',' @@)* ')'"`
-		Engine      *TableEngine   `parser:"@@"`
-		Clauses     []TableClause  `parser:"@@*"`
-		Comment     *string        `parser:"('COMMENT' @String)?"`
-		Semicolon   bool           `parser:"';'"`
+		LeadingComments   []string       `parser:"@(Comment | MultilineComment)*"`
+		Create            string         `parser:"'CREATE'"`
+		OrReplace         bool           `parser:"@('OR' 'REPLACE')?"`
+		Table             string         `parser:"'TABLE'"`
+		IfNotExists       bool           `parser:"@('IF' 'NOT' 'EXISTS')?"`
+		Database          *string        `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name              string         `parser:"@(Ident | BacktickIdent)"`
+		OnCluster         *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Elements          []TableElement `parser:"'(' @@ (',' @@)* ')'"`
+		PreEngineComments []string       `parser:"@(Comment | MultilineComment)*"`
+		Engine            *TableEngine   `parser:"@@"`
+		Clauses           []TableClause  `parser:"@@*"`
+		Comment           *string        `parser:"('COMMENT' @String)?"`
+		TrailingComments  []string       `parser:"@(Comment | MultilineComment)*"`
+		Semicolon         bool           `parser:"';'"`
 	}
 
 	// TableClause represents any clause that can appear after ENGINE in a CREATE TABLE statement
 	// This allows clauses to be specified in any order
 	TableClause struct {
-		OrderBy     *OrderByClause       `parser:"@@"`
-		PartitionBy *PartitionByClause   `parser:"| @@"`
-		PrimaryKey  *PrimaryKeyClause    `parser:"| @@"`
-		SampleBy    *SampleByClause      `parser:"| @@"`
-		TTL         *TableTTLClause      `parser:"| @@"`
-		Settings    *TableSettingsClause `parser:"| @@"`
+		LeadingComments  []string             `parser:"@(Comment | MultilineComment)*"`
+		OrderBy          *OrderByClause       `parser:"@@"`
+		PartitionBy      *PartitionByClause   `parser:"| @@"`
+		PrimaryKey       *PrimaryKeyClause    `parser:"| @@"`
+		SampleBy         *SampleByClause      `parser:"| @@"`
+		TTL              *TableTTLClause      `parser:"| @@"`
+		Settings         *TableSettingsClause `parser:"| @@"`
+		TrailingComments []string             `parser:"@(Comment | MultilineComment)*"`
 	}
 
 	// TableElement represents an element within table definition (column, index, constraint, or projection)
@@ -142,9 +147,10 @@ type (
 	// TableEngine represents the ENGINE clause for tables
 	// Examples: ENGINE = MergeTree(), ENGINE = ReplicatedMergeTree('/path', 'replica')
 	TableEngine struct {
-		Engine     string            `parser:"'ENGINE' '='"`
-		Name       string            `parser:"@(Ident | BacktickIdent)"`
-		Parameters []EngineParameter `parser:"('(' (@@ (',' @@)*)? ')')?"`
+		Engine           string            `parser:"'ENGINE' '='"`
+		Name             string            `parser:"@(Ident | BacktickIdent)"`
+		Parameters       []EngineParameter `parser:"('(' (@@ (',' @@)*)? ')')?"`
+		TrailingComments []string          `parser:"@(Comment | MultilineComment)*"`
 	}
 
 	// EngineParameter represents a parameter in an ENGINE clause
@@ -202,12 +208,14 @@ type (
 	// ClickHouse syntax:
 	//   ATTACH TABLE [IF NOT EXISTS] [db.]table_name [ON CLUSTER cluster]
 	AttachTableStmt struct {
-		Attach      string  `parser:"'ATTACH' 'TABLE'"`
-		IfNotExists bool    `parser:"('IF' 'NOT' 'EXISTS')?"`
-		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon   bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Attach           string   `parser:"'ATTACH' 'TABLE'"`
+		IfNotExists      bool     `parser:"('IF' 'NOT' 'EXISTS')?"`
+		Database         *string  `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// DetachTableStmt represents a DETACH TABLE statement.
@@ -215,14 +223,16 @@ type (
 	// ClickHouse syntax:
 	//   DETACH TABLE [IF EXISTS] [db.]table_name [ON CLUSTER cluster] [PERMANENTLY] [SYNC]
 	DetachTableStmt struct {
-		Detach      string  `parser:"'DETACH' 'TABLE'"`
-		IfExists    bool    `parser:"('IF' 'EXISTS')?"`
-		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Permanently bool    `parser:"@'PERMANENTLY'?"`
-		Sync        bool    `parser:"@'SYNC'?"`
-		Semicolon   bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Detach           string   `parser:"'DETACH' 'TABLE'"`
+		IfExists         bool     `parser:"('IF' 'EXISTS')?"`
+		Database         *string  `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Permanently      bool     `parser:"@'PERMANENTLY'?"`
+		Sync             bool     `parser:"@'SYNC'?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// DropTableStmt represents a DROP TABLE statement.
@@ -230,13 +240,15 @@ type (
 	// ClickHouse syntax:
 	//   DROP TABLE [IF EXISTS] [db.]table_name [ON CLUSTER cluster] [SYNC]
 	DropTableStmt struct {
-		Drop      string  `parser:"'DROP' 'TABLE'"`
-		IfExists  bool    `parser:"('IF' 'EXISTS')?"`
-		Database  *string `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Sync      bool    `parser:"@'SYNC'?"`
-		Semicolon bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Drop             string   `parser:"'DROP' 'TABLE'"`
+		IfExists         bool     `parser:"('IF' 'EXISTS')?"`
+		Database         *string  `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Sync             bool     `parser:"@'SYNC'?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// RenameTableStmt represents a RENAME TABLE statement.
@@ -244,10 +256,12 @@ type (
 	// ClickHouse syntax:
 	//   RENAME TABLE [db.]table1 TO [db.]table2, [db.]table3 TO [db.]table4, ... [ON CLUSTER cluster]
 	RenameTableStmt struct {
-		Rename    string        `parser:"'RENAME' 'TABLE'"`
-		Renames   []TableRename `parser:"@@ (',' @@)*"`
-		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon bool          `parser:"';'"`
+		LeadingComments  []string      `parser:"@(Comment | MultilineComment)*"`
+		Rename           string        `parser:"'RENAME' 'TABLE'"`
+		Renames          []TableRename `parser:"@@ (',' @@)*"`
+		OnCluster        *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string      `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool          `parser:"';'"`
 	}
 
 	// TableRename represents a single table rename operation
@@ -275,13 +289,15 @@ type (
 	// - MODIFY ORDER BY/SAMPLE BY
 	// - MODIFY SETTING
 	AlterTableStmt struct {
-		Alter      string                `parser:"'ALTER' 'TABLE'"`
-		IfExists   bool                  `parser:"@('IF' 'EXISTS')?"`
-		Database   *string               `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name       string                `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string               `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Operations []AlterTableOperation `parser:"@@ (',' @@)*"`
-		Semicolon  bool                  `parser:"';'"`
+		LeadingComments  []string              `parser:"@(Comment | MultilineComment)*"`
+		Alter            string                `parser:"'ALTER' 'TABLE'"`
+		IfExists         bool                  `parser:"@('IF' 'EXISTS')?"`
+		Database         *string               `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string                `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string               `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Operations       []AlterTableOperation `parser:"@@ (',' @@)*"`
+		TrailingComments []string              `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool                  `parser:"';'"`
 	}
 
 	// AlterTableOperation represents a single ALTER TABLE operation
@@ -633,4 +649,64 @@ func (p *EngineParameter) Value() string {
 		return *p.Ident
 	}
 	return ""
+}
+
+// GetLeadingComments returns the leading comments for CreateTableStmt
+func (s *CreateTableStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for CreateTableStmt
+func (s *CreateTableStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AttachTableStmt
+func (s *AttachTableStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AttachTableStmt
+func (s *AttachTableStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DetachTableStmt
+func (s *DetachTableStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DetachTableStmt
+func (s *DetachTableStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DropTableStmt
+func (s *DropTableStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DropTableStmt
+func (s *DropTableStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for RenameTableStmt
+func (s *RenameTableStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for RenameTableStmt
+func (s *RenameTableStmt) GetTrailingComments() []string {
+	return s.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AlterTableStmt
+func (s *AlterTableStmt) GetLeadingComments() []string {
+	return s.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AlterTableStmt
+func (s *AlterTableStmt) GetTrailingComments() []string {
+	return s.TrailingComments
 }

--- a/pkg/parser/testdata/comments_table.sql
+++ b/pkg/parser/testdata/comments_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE demo (
+  -- A special field
+  id UInt32,
+  name LowCardinality(String)
+)
+-- Use MergeTree engine.
+ENGINE = MergeTree
+-- Primary key/order by is simple.
+PRIMARY KEY(id);

--- a/pkg/parser/testdata/comments_table.yaml
+++ b/pkg/parser/testdata/comments_table.yaml
@@ -1,0 +1,10 @@
+tables:
+    - name: demo
+      operation: CREATE
+      engine: MergeTree
+      columns:
+        - name: id
+          data_type: UInt32
+        - name: name
+          data_type: LowCardinality(String)
+      primary_key: expression

--- a/pkg/parser/view.go
+++ b/pkg/parser/view.go
@@ -8,61 +8,69 @@ type (
 	//   [TO [db.]table_name] [ENGINE = engine] [POPULATE]
 	//   AS SELECT ...
 	CreateViewStmt struct {
-		Create       string           `parser:"'CREATE'"`
-		OrReplace    bool             `parser:"@('OR' 'REPLACE')?"`
-		Materialized bool             `parser:"@'MATERIALIZED'?"`
-		View         string           `parser:"'VIEW'"`
-		IfNotExists  bool             `parser:"@('IF' 'NOT' 'EXISTS')?"`
-		Database     *string          `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name         string           `parser:"@(Ident | BacktickIdent)"`
-		OnCluster    *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		To           *string          `parser:"('TO' @((Ident | BacktickIdent) ('.' (Ident | BacktickIdent))?))?"`
-		Engine       *ViewEngine      `parser:"@@?"`
-		Populate     bool             `parser:"@'POPULATE'?"`
-		AsSelect     *SelectStatement `parser:"'AS' @@"`
-		Semicolon    bool             `parser:"';'"`
+		LeadingComments  []string         `parser:"@(Comment | MultilineComment)*"`
+		Create           string           `parser:"'CREATE'"`
+		OrReplace        bool             `parser:"@('OR' 'REPLACE')?"`
+		Materialized     bool             `parser:"@'MATERIALIZED'?"`
+		View             string           `parser:"'VIEW'"`
+		IfNotExists      bool             `parser:"@('IF' 'NOT' 'EXISTS')?"`
+		Database         *string          `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string           `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		To               *string          `parser:"('TO' @((Ident | BacktickIdent) ('.' (Ident | BacktickIdent))?))?"`
+		Engine           *ViewEngine      `parser:"@@?"`
+		Populate         bool             `parser:"@'POPULATE'?"`
+		AsSelect         *SelectStatement `parser:"'AS' @@"`
+		TrailingComments []string         `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool             `parser:"';'"`
 	}
 
 	// AttachViewStmt represents an ATTACH VIEW statement (for regular views only).
 	// ClickHouse syntax:
 	//   ATTACH VIEW [IF NOT EXISTS] [db.]view_name [ON CLUSTER cluster]
 	AttachViewStmt struct {
-		Attach      string  `parser:"'ATTACH'"`
-		View        string  `parser:"'VIEW'"`
-		IfNotExists bool    `parser:"@('IF' 'NOT' 'EXISTS')?"`
-		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Semicolon   bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Attach           string   `parser:"'ATTACH'"`
+		View             string   `parser:"'VIEW'"`
+		IfNotExists      bool     `parser:"@('IF' 'NOT' 'EXISTS')?"`
+		Database         *string  `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// DetachViewStmt represents a DETACH VIEW statement (for regular views only).
 	// ClickHouse syntax:
 	//   DETACH VIEW [IF EXISTS] [db.]view_name [ON CLUSTER cluster] [PERMANENTLY] [SYNC]
 	DetachViewStmt struct {
-		Detach      string  `parser:"'DETACH'"`
-		View        string  `parser:"'VIEW'"`
-		IfExists    bool    `parser:"@('IF' 'EXISTS')?"`
-		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Permanently bool    `parser:"@'PERMANENTLY'?"`
-		Sync        bool    `parser:"@'SYNC'?"`
-		Semicolon   bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Detach           string   `parser:"'DETACH'"`
+		View             string   `parser:"'VIEW'"`
+		IfExists         bool     `parser:"@('IF' 'EXISTS')?"`
+		Database         *string  `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Permanently      bool     `parser:"@'PERMANENTLY'?"`
+		Sync             bool     `parser:"@'SYNC'?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// DropViewStmt represents a DROP VIEW statement (for regular views only).
 	// ClickHouse syntax:
 	//   DROP VIEW [IF EXISTS] [db.]view_name [ON CLUSTER cluster] [SYNC]
 	DropViewStmt struct {
-		Drop      string  `parser:"'DROP'"`
-		View      string  `parser:"'VIEW'"`
-		IfExists  bool    `parser:"@('IF' 'EXISTS')?"`
-		Database  *string `parser:"(@(Ident | BacktickIdent) '.')?"`
-		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
-		Sync      bool    `parser:"@'SYNC'?"`
-		Semicolon bool    `parser:"';'"`
+		LeadingComments  []string `parser:"@(Comment | MultilineComment)*"`
+		Drop             string   `parser:"'DROP'"`
+		View             string   `parser:"'VIEW'"`
+		IfExists         bool     `parser:"@('IF' 'EXISTS')?"`
+		Database         *string  `parser:"(@(Ident | BacktickIdent) '.')?"`
+		Name             string   `parser:"@(Ident | BacktickIdent)"`
+		OnCluster        *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Sync             bool     `parser:"@'SYNC'?"`
+		TrailingComments []string `parser:"@(Comment | MultilineComment)*"`
+		Semicolon        bool     `parser:"';'"`
 	}
 
 	// ViewEngine represents ENGINE = clause for materialized views.
@@ -102,3 +110,43 @@ type (
 		Expression Expression `parser:"@@"`
 	}
 )
+
+// GetLeadingComments returns the leading comments for CreateViewStmt
+func (c *CreateViewStmt) GetLeadingComments() []string {
+	return c.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for CreateViewStmt
+func (c *CreateViewStmt) GetTrailingComments() []string {
+	return c.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for AttachViewStmt
+func (a *AttachViewStmt) GetLeadingComments() []string {
+	return a.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for AttachViewStmt
+func (a *AttachViewStmt) GetTrailingComments() []string {
+	return a.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DetachViewStmt
+func (d *DetachViewStmt) GetLeadingComments() []string {
+	return d.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DetachViewStmt
+func (d *DetachViewStmt) GetTrailingComments() []string {
+	return d.TrailingComments
+}
+
+// GetLeadingComments returns the leading comments for DropViewStmt
+func (d *DropViewStmt) GetLeadingComments() []string {
+	return d.LeadingComments
+}
+
+// GetTrailingComments returns the trailing comments for DropViewStmt
+func (d *DropViewStmt) GetTrailingComments() []string {
+	return d.TrailingComments
+}


### PR DESCRIPTION
This change implements comprehensive comment support for ClickHouse DDL statements using an AST-based approach instead of text parsing.

Problem:
- Comments in SQL files were being lost during parse/format cycle
- Special directives like `-- housekeeper:import` need to be preserved
- Text-based comment handling was fragile and unreliable

Solution:
- Extended lexer to capture comments as tokens instead of eliding them
- Added LeadingComments and TrailingComments fields to all DDL statement types
- Implemented commentable interface with GetLeadingComments/GetTrailingComments methods
- Created formatWithComments wrapper for DRY comment formatting
- Refactored createTable function to reduce cognitive complexity (54 → <30)

Statement types with comment support:
- Databases (CREATE, ALTER, ATTACH, DETACH, DROP, RENAME)
- Tables (CREATE, ALTER, ATTACH, DETACH, DROP, RENAME)
- Dictionaries (CREATE, ATTACH, DETACH, DROP, RENAME)
- Views (CREATE, ATTACH, DETACH, DROP)
- Functions (CREATE, DROP)
- Roles (CREATE, ALTER, DROP)
- Permissions (GRANT, REVOKE)

Features:
- Sequential comments stay together without blank lines
- Comments separated by blank lines get preserved spacing
- File-level comments and import directives preserved
- All comment types: single-line (--), multi-line (/* */), and directives

Testing:
- Added comprehensive test files demonstrating comment preservation
- All existing tests pass
- Linter passes with 0 issues