### PR TITLE
[clickhouse]: Fix ON CLUSTER injection in CREATE FUNCTION statements

### DIFF
--- a/pkg/clickhouse/functions.go
+++ b/pkg/clickhouse/functions.go
@@ -88,16 +88,9 @@ func (c *Client) addOnClusterToFunction(createQuery string) string {
 		return createQuery // Already has ON CLUSTER
 	}
 
-	// Find the function name end position to insert ON CLUSTER
-	// Look for the space before "AS"
-	beforeAs := strings.LastIndex(createQuery[:asPos], " ")
-	if beforeAs == -1 {
-		return createQuery // Can't find insertion point
-	}
-
-	// Insert ON CLUSTER clause
+	// Insert ON CLUSTER clause right before " AS "
 	clusterClause := fmt.Sprintf(" ON CLUSTER `%s`", c.options.Cluster)
-	result := createQuery[:beforeAs] + clusterClause + createQuery[beforeAs:]
+	result := createQuery[:asPos] + clusterClause + createQuery[asPos:]
 
 	return result
 }

--- a/pkg/clickhouse/functions_test.go
+++ b/pkg/clickhouse/functions_test.go
@@ -1,0 +1,77 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddOnClusterToFunction(t *testing.T) {
+	tests := []struct {
+		name        string
+		createQuery string
+		cluster     string
+		expected    string
+	}{
+		{
+			name:        "function with backticks",
+			createQuery: "CREATE FUNCTION `normalizedBrowser` AS (`br`) -> multiIf(lower(`br`) = 'firefox', 'Firefox', 'Other')",
+			cluster:     "warehouse",
+			expected:    "CREATE FUNCTION `normalizedBrowser` ON CLUSTER `warehouse` AS (`br`) -> multiIf(lower(`br`) = 'firefox', 'Firefox', 'Other')",
+		},
+		{
+			name:        "function without backticks",
+			createQuery: "CREATE FUNCTION normalizedBrowser AS (br) -> multiIf(lower(br) = 'firefox', 'Firefox', 'Other')",
+			cluster:     "production",
+			expected:    "CREATE FUNCTION normalizedBrowser ON CLUSTER `production` AS (br) -> multiIf(lower(br) = 'firefox', 'Firefox', 'Other')",
+		},
+		{
+			name:        "function with no parameters",
+			createQuery: "CREATE FUNCTION getCurrentTime AS () -> now()",
+			cluster:     "test",
+			expected:    "CREATE FUNCTION getCurrentTime ON CLUSTER `test` AS () -> now()",
+		},
+		{
+			name:        "function already has ON CLUSTER",
+			createQuery: "CREATE FUNCTION test ON CLUSTER existing AS () -> now()",
+			cluster:     "new_cluster",
+			expected:    "CREATE FUNCTION test ON CLUSTER existing AS () -> now()",
+		},
+		{
+			name:        "empty cluster name",
+			createQuery: "CREATE FUNCTION test AS () -> now()",
+			cluster:     "",
+			expected:    "CREATE FUNCTION test AS () -> now()",
+		},
+		{
+			name: "complex multiline function",
+			createQuery: `CREATE FUNCTION normalizedOS AS (os) -> multiIf(
+				startsWith(lower(os), 'windows'), 'Windows',
+				startsWith(lower(os), 'mac'), 'Mac',
+				lower(os) IN ('ios', 'iphone'), 'iOS',
+				lower(os) = 'android', 'Android',
+				'Other'
+			)`,
+			cluster: "analytics",
+			expected: `CREATE FUNCTION normalizedOS ON CLUSTER ` + "`analytics`" + ` AS (os) -> multiIf(
+				startsWith(lower(os), 'windows'), 'Windows',
+				startsWith(lower(os), 'mac'), 'Mac',
+				lower(os) IN ('ios', 'iphone'), 'iOS',
+				lower(os) = 'android', 'Android',
+				'Other'
+			)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				options: ClientOptions{
+					Cluster: tt.cluster,
+				},
+			}
+			result := client.addOnClusterToFunction(tt.createQuery)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
The addOnClusterToFunction method was incorrectly injecting ON CLUSTER clauses between CREATE FUNCTION and the function name, causing parser errors during schema extraction. This resulted in invalid SQL like: CREATE FUNCTION ON CLUSTER warehouse name AS ...

Fixed by inserting the ON CLUSTER clause directly before the AS keyword, producing correct syntax:
CREATE FUNCTION name ON CLUSTER warehouse AS ...

• Fixed ON CLUSTER insertion position in addOnClusterToFunction • Added comprehensive test coverage for cluster injection scenarios • Resolves parsing failures when running diff after migrations