### PR TITLE
[parser]: Fix table function parsing in SELECT FROM clause

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1074,6 +1074,9 @@ func generateTestCaseFromSQL(sql *SQL) TestCase {
 					} else {
 						expectedQuery.From = table.Table
 					}
+				} else if sel.From.Table.Function != nil {
+					// Table function like numbers(10), remote('host', 'db', 'table'), etc.
+					expectedQuery.From = sel.From.Table.Function.Function.Name
 				}
 
 				// Count JOINs

--- a/pkg/parser/query.go
+++ b/pkg/parser/query.go
@@ -53,12 +53,12 @@ type (
 
 	// TableRef represents a table reference (table, subquery, or function)
 	TableRef struct {
-		// Table reference with optional alias
-		TableName *TableNameWithAlias `parser:"@@"`
+		// Try table function first (has parentheses to distinguish it)
+		Function *FunctionWithAlias `parser:"@@"`
 		// OR subquery with optional alias
 		Subquery *SubqueryWithAlias `parser:"| @@"`
-		// OR table function with optional alias
-		Function *FunctionWithAlias `parser:"| @@"`
+		// Fall back to table reference if no function call syntax found
+		TableName *TableNameWithAlias `parser:"| @@"`
 	}
 
 	// TableNameWithAlias represents a table name with optional alias

--- a/pkg/parser/testdata/query.sql
+++ b/pkg/parser/testdata/query.sql
@@ -151,3 +151,14 @@ SELECT a, b FROM t ORDER BY a WITH FILL FROM 0 TO 100 STEP 10, b WITH FILL FROM 
 
 -- WITH FILL with all modifiers and INTERPOLATE
 SELECT date, value, count FROM metrics ORDER BY date WITH FILL FROM '2024-01-01' TO '2024-12-31' STEP INTERVAL 1 DAY STALENESS INTERVAL 2 DAY INTERPOLATE (value AS value, count AS 0);
+
+-- Table functions in FROM clause
+SELECT * FROM numbers(10);
+
+SELECT toFloat32(number % 10) AS n FROM numbers(10) WHERE number % 3 = 1;
+
+SELECT * FROM numbers(100) AS n;
+
+SELECT * FROM remote('localhost:9000', 'db', 'table');
+
+SELECT * FROM cluster('my_cluster', 'db', 'table') AS t;

--- a/pkg/parser/testdata/query.yaml
+++ b/pkg/parser/testdata/query.yaml
@@ -211,12 +211,17 @@ queries:
       has_order_by: true
     - columns:
         - '*'
+      from: numbers
     - columns:
         - non_wildcard
+      from: numbers
       has_where: true
     - columns:
         - '*'
+      from: numbers
     - columns:
         - '*'
+      from: remote
     - columns:
         - '*'
+      from: cluster

--- a/pkg/parser/testdata/query.yaml
+++ b/pkg/parser/testdata/query.yaml
@@ -209,3 +209,14 @@ queries:
         - non_wildcard
       from: metrics
       has_order_by: true
+    - columns:
+        - '*'
+    - columns:
+        - non_wildcard
+      has_where: true
+    - columns:
+        - '*'
+    - columns:
+        - '*'
+    - columns:
+        - '*'


### PR DESCRIPTION
Table functions with arguments like `numbers(10)` failed to parse in SELECT statements because the parser tried alternatives in the wrong order. The TableRef struct tried TableName first, which matched the identifier, leaving parentheses unparsed.

- Reorder TableRef alternatives to try Function before TableName
- Match pattern used in TableSource for CREATE TABLE AS
- Add test cases for table functions with arguments in FROM clause