### PR TITLE
[parser]: Add sub-second interval unit support

### DIFF
--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -246,7 +246,7 @@ type (
 	IntervalExpr struct {
 		Interval string `parser:"'INTERVAL'"`
 		Value    string `parser:"@Number"`
-		Unit     string `parser:"@('SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'QUARTER' | 'YEAR')"`
+		Unit     string `parser:"@('NANOSECOND' | 'MICROSECOND' | 'MILLISECOND' | 'SECOND' | 'MINUTE' | 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'QUARTER' | 'YEAR')"`
 	}
 
 	// ExtractExpression represents EXTRACT expressions

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -112,6 +112,10 @@ func TestExpressionParsing(t *testing.T) {
 		// INTERVAL - now working!
 		{"INTERVAL", "INTERVAL 1 DAY", true},
 		{"INTERVAL in expression", "timestamp > now() - INTERVAL 7 DAY", true},
+		{"INTERVAL MILLISECOND", "INTERVAL 100 MILLISECOND", true},
+		{"INTERVAL MICROSECOND", "INTERVAL 500 MICROSECOND", true},
+		{"INTERVAL NANOSECOND", "INTERVAL 1000 NANOSECOND", true},
+		{"INTERVAL sub-second in expression", "timestamp + INTERVAL 1 MILLISECOND", true},
 
 		// Complex expressions from ALTER TABLE
 		{"CHECK constraint", "id > 0", true},

--- a/pkg/parser/query_stmt_test.go
+++ b/pkg/parser/query_stmt_test.go
@@ -97,6 +97,7 @@ func TestSelectOrderBy(t *testing.T) {
 		{name: "with_fill_interpolate_columns", sql: `SELECT date, value FROM metrics ORDER BY date WITH FILL INTERPOLATE (value);`},
 		{name: "with_fill_interpolate_as", sql: `SELECT date, value FROM metrics ORDER BY date WITH FILL INTERPOLATE (value AS value);`},
 		{name: "with_fill_interval", sql: `SELECT date, value FROM metrics ORDER BY date WITH FILL STEP INTERVAL 1 DAY;`},
+		{name: "with_fill_interval_millisecond", sql: `SELECT ts, value FROM metrics ORDER BY ts WITH FILL FROM toDateTime64(ts, 3) TO toDateTime64(ts, 3) + INTERVAL 1 MILLISECOND STEP toIntervalMillisecond(100);`},
 		{name: "with_fill_date_range", sql: `SELECT date, value FROM metrics ORDER BY date WITH FILL FROM '2024-01-01' TO '2024-12-31' STEP INTERVAL 1 DAY;`},
 		{name: "with_fill_staleness", sql: `SELECT date, value FROM metrics ORDER BY date WITH FILL STALENESS INTERVAL 1 HOUR;`},
 		{name: "mixed_fill", sql: `SELECT a, b FROM t ORDER BY a ASC WITH FILL FROM 0 TO 100, b DESC;`},

--- a/pkg/parser/testdata/query/order_by/with_fill_interval_millisecond.sql
+++ b/pkg/parser/testdata/query/order_by/with_fill_interval_millisecond.sql
@@ -1,0 +1,5 @@
+SELECT
+    `ts`,
+    `value`
+FROM `metrics`
+ORDER BY `ts` WITH FILL FROM toDateTime64(`ts`, 3) TO toDateTime64(`ts`, 3) + INTERVAL 1 MILLISECOND STEP toIntervalMillisecond(100);


### PR DESCRIPTION
The INTERVAL expression parser only supported units from SECOND through YEAR, causing queries using MILLISECOND, MICROSECOND, or NANOSECOND to fail parsing. This is needed for high-precision time series queries with ORDER BY ... WITH FILL.

- Add NANOSECOND, MICROSECOND, MILLISECOND to IntervalExpr unit parser
- Add expression tests for sub-second interval units
- Add query test for WITH FILL using INTERVAL MILLISECOND