### PR TITLE
Fix spurious ALTER TABLE statements caused by ClickHouse normalization

### DIFF
--- a/cmd/housekeeper/main.go
+++ b/cmd/housekeeper/main.go
@@ -81,6 +81,9 @@ func main() {
 	pwd, _ := os.Getwd()
 
 	app := fx.New(
+		// Extend fx's automatic startup timeout - if you see an exit code of (1) very possibly its fx killing the
+		// process as it hasnt goten past the 'onstart' process.
+		fx.StartTimeout(10*time.Minute),
 		fx.Supply(
 			args,
 			Params{

--- a/pkg/clickhouse/views.go
+++ b/pkg/clickhouse/views.go
@@ -27,22 +27,59 @@ func cleanViewStatement(createQuery string) string {
 	cleaned = definerPattern.ReplaceAllString(cleaned, "")
 
 	// ClickHouse may return CREATE VIEW name (col1 Type1, ...) AS SELECT
-	// or CREATE MATERIALIZED VIEW name ... APPEND TO table_name (col1 Type1, ...) AS SELECT
+	// or CREATE MATERIALIZED VIEW name ... APPEND TO table_name (col1 Type1, ...) AS SELECT/WITH
 	// We need to remove the column definitions if they exist
-	// Find the first ( that appears after the view name and before AS
-	asPos := strings.Index(cleaned, " AS ")
-	if asPos > 0 {
-		// Find the first ( before AS
-		prefixPart := cleaned[:asPos]
-		parenPos := strings.Index(prefixPart, "(")
+	//
+	// Find the main "AS" that introduces the SELECT query (not CTEs like "cte_name AS (SELECT...)")
+	// The main AS is followed by either SELECT or WITH (for CTEs)
+	mainAsPattern := regexp.MustCompile(`\)\s*AS\s+(SELECT|WITH)\s`)
+	mainAsMatch := mainAsPattern.FindStringIndex(cleaned)
+
+	if mainAsMatch != nil {
+		// Found pattern like ") AS SELECT" or ") AS WITH"
+		// The column definitions are between the first ( and this )
+		prefixEnd := mainAsMatch[0] + 1 // Position right after the closing )
+		prefixPart := cleaned[:prefixEnd]
+
+		// Find the opening ( of column definitions (not function calls)
+		// It should be after APPEND TO table_name or after view_name
+		parenPos := findColumnDefOpenParen(prefixPart)
 		if parenPos > 0 {
-			// There are column definitions between the opening paren and AS
-			// Remove them by taking everything before the opening paren and after AS
+			// Remove column definitions: take before ( and from AS onwards
+			asPos := mainAsMatch[0] + 1 // Position of the space before AS
 			cleaned = cleaned[:parenPos] + cleaned[asPos:]
 		}
 	}
 
 	return cleaned
+}
+
+// findColumnDefOpenParen finds the opening parenthesis of column definitions
+// in a materialized view statement prefix (everything up to and including the closing paren).
+// Returns -1 if no column definitions are found.
+func findColumnDefOpenParen(prefix string) int {
+	// The column definitions open paren should be:
+	// 1. After "APPEND TO table_name" or "TO table_name" for MVs
+	// 2. After the view name for regular views
+	// 3. NOT be part of a function call like LowCardinality(...)
+
+	// Look for patterns like "TO table_name\n(" or "TO table_name ("
+	toPattern := regexp.MustCompile(`TO\s+[\w.]+\s*\(`)
+	toMatch := toPattern.FindStringIndex(prefix)
+	if toMatch != nil {
+		// Return position of the ( in the match
+		return strings.LastIndex(prefix[:toMatch[1]], "(")
+	}
+
+	// For regular views without TO clause, look for "VIEW name\n(" or "VIEW name ("
+	// after any ON CLUSTER clause
+	viewPattern := regexp.MustCompile(`VIEW\s+[\w.]+(?:\s+ON\s+CLUSTER\s+[\w.]+)?\s*\(`)
+	viewMatch := viewPattern.FindStringIndex(prefix)
+	if viewMatch != nil {
+		return strings.LastIndex(prefix[:viewMatch[1]], "(")
+	}
+
+	return -1
 }
 
 // extractViews retrieves all view definitions (both regular and materialized) from the ClickHouse instance.

--- a/pkg/clickhouse/views.go
+++ b/pkg/clickhouse/views.go
@@ -32,54 +32,204 @@ func cleanViewStatement(createQuery string) string {
 	//
 	// Find the main "AS" that introduces the SELECT query (not CTEs like "cte_name AS (SELECT...)")
 	// The main AS is followed by either SELECT or WITH (for CTEs)
-	mainAsPattern := regexp.MustCompile(`\)\s*AS\s+(SELECT|WITH)\s`)
+	// Use flexible pattern to handle various whitespace (spaces, newlines, tabs)
+	mainAsPattern := regexp.MustCompile(`\)\s*AS\s+(SELECT|WITH)(?:\s|;|$)`)
 	mainAsMatch := mainAsPattern.FindStringIndex(cleaned)
 
 	if mainAsMatch != nil {
 		// Found pattern like ") AS SELECT" or ") AS WITH"
-		// The column definitions are between the first ( and this )
-		prefixEnd := mainAsMatch[0] + 1 // Position right after the closing )
-		prefixPart := cleaned[:prefixEnd]
+		// The column definitions are between the opening ( and this closing )
+		closingParenPos := mainAsMatch[0] // Position of the closing )
+		prefixPart := cleaned[:closingParenPos+1]
 
-		// Find the opening ( of column definitions (not function calls)
-		// It should be after APPEND TO table_name or after view_name
-		parenPos := findColumnDefOpenParen(prefixPart)
-		if parenPos > 0 {
+		// Find the opening ( of column definitions by working backwards and counting parens
+		// This handles nested parentheses in column types like AggregateFunction(argMin, String, DateTime)
+		parenPos := findColumnDefOpenParenByCounting(prefixPart)
+		if parenPos < 0 {
+			// Fallback: look for "TO table_name (" directly (handles local instances without ON CLUSTER)
+			parenPos = findColumnDefOpenParenFallback(prefixPart)
+		}
+		if parenPos >= 0 {
 			// Remove column definitions: take before ( and from AS onwards
-			asPos := mainAsMatch[0] + 1 // Position of the space before AS
+			asPos := mainAsMatch[0] + 1 // Position right after the closing )
 			cleaned = cleaned[:parenPos] + cleaned[asPos:]
 		}
 	}
 
-	return cleaned
+	// Normalize whitespace after removal (multiple spaces/newlines to single space)
+	cleaned = regexp.MustCompile(`\s+`).ReplaceAllString(cleaned, " ")
+
+	// ClickHouse can return CAST(expr, 'Type') but our parser expects CAST(expr AS Type)
+	cleaned = normalizeCastTwoArgToAs(cleaned)
+
+	return strings.TrimSpace(cleaned)
 }
 
-// findColumnDefOpenParen finds the opening parenthesis of column definitions
-// in a materialized view statement prefix (everything up to and including the closing paren).
-// Returns -1 if no column definitions are found.
-func findColumnDefOpenParen(prefix string) int {
-	// The column definitions open paren should be:
-	// 1. After "APPEND TO table_name" or "TO table_name" for MVs
-	// 2. After the view name for regular views
-	// 3. NOT be part of a function call like LowCardinality(...)
+// normalizeCastTwoArgToAs converts ClickHouse's CAST(expr, 'Type') to CAST(expr AS Type)
+// so the parser (which only supports CAST(expr AS type)) can parse it.
+// Handles nested parens in expr and type strings like 'Nullable(Decimal64(2))'.
+func normalizeCastTwoArgToAs(s string) string {
+	const castKeyword = "CAST("
+	from := 0
+	for {
+		idx := strings.Index(strings.ToUpper(s[from:]), castKeyword)
+		if idx < 0 {
+			return s
+		}
+		start := from + idx
+		openParen := start + len(castKeyword) - 1
+		pos := openParen + 1
+		depth := 1
+		exprEnd := -1
+		for pos < len(s) && depth > 0 {
+			c := s[pos]
+			switch c {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			case ',':
+				if depth == 1 {
+					p := pos + 1
+					for p < len(s) && (s[p] == ' ' || s[p] == '\t' || s[p] == '\n' || s[p] == '\r') {
+						p++
+					}
+					if p < len(s) && s[p] == '\'' {
+						exprEnd = pos
+						break
+					}
+				}
+			}
+			pos++
+		}
+		if exprEnd < 0 {
+			from = start + 1
+			continue
+		}
+		expr := strings.TrimSpace(s[openParen+1 : exprEnd])
+		typeStart := exprEnd + 1
+		for typeStart < len(s) && (s[typeStart] == ' ' || s[typeStart] == '\t' || s[typeStart] == '\n' || s[typeStart] == '\r') {
+			typeStart++
+		}
+		if typeStart >= len(s) || s[typeStart] != '\'' {
+			from = start + 1
+			continue
+		}
+		typeContentStart := typeStart + 1
+		typeContentEnd := typeContentStart
+		for typeContentEnd < len(s) {
+			if s[typeContentEnd] == '\'' {
+				if typeContentEnd+1 < len(s) && s[typeContentEnd+1] == '\'' {
+					typeContentEnd += 2
+					continue
+				}
+				break
+			}
+			typeContentEnd++
+		}
+		typeStr := s[typeContentStart:typeContentEnd]
+		typeStr = strings.ReplaceAll(typeStr, "''", "'")
+		closeParen := typeContentEnd + 1
+		for closeParen < len(s) && (s[closeParen] == ' ' || s[closeParen] == '\t' || s[closeParen] == '\n' || s[closeParen] == '\r') {
+			closeParen++
+		}
+		if closeParen >= len(s) || s[closeParen] != ')' {
+			from = start + 1
+			continue
+		}
+		closeParen++
+		replacement := "CAST(" + expr + " AS " + typeStr + ")"
+		s = s[:start] + replacement + s[closeParen:]
+		from = start + len(replacement)
+	}
+}
 
-	// Look for patterns like "TO table_name\n(" or "TO table_name ("
-	toPattern := regexp.MustCompile(`TO\s+[\w.]+\s*\(`)
-	toMatch := toPattern.FindStringIndex(prefix)
-	if toMatch != nil {
-		// Return position of the ( in the match
-		return strings.LastIndex(prefix[:toMatch[1]], "(")
+// findColumnDefOpenParenByCounting finds the opening parenthesis of column definitions
+// by working backwards from the closing paren and counting parentheses.
+// This is more robust than regex matching and handles nested parentheses in column types.
+func findColumnDefOpenParenByCounting(prefix string) int {
+	if len(prefix) == 0 {
+		return -1
 	}
 
-	// For regular views without TO clause, look for "VIEW name\n(" or "VIEW name ("
-	// after any ON CLUSTER clause
-	viewPattern := regexp.MustCompile(`VIEW\s+[\w.]+(?:\s+ON\s+CLUSTER\s+[\w.]+)?\s*\(`)
-	viewMatch := viewPattern.FindStringIndex(prefix)
-	if viewMatch != nil {
-		return strings.LastIndex(prefix[:viewMatch[1]], "(")
+	// Start from the last character (the closing paren) and work backwards
+	// Count parentheses to find the matching opening paren
+	depth := 0
+	closingParenPos := len(prefix) - 1
+
+	for i := closingParenPos; i >= 0; i-- {
+		char := prefix[i]
+		if char == ')' {
+			depth++
+		} else if char == '(' {
+			depth--
+			if depth == 0 {
+				// Found the matching opening paren
+				// Now check if this looks like column definitions (after TO/APPEND TO or after VIEW name)
+				beforeParen := prefix[:i]
+				// Check if this paren is after TO/APPEND TO or after VIEW name
+				// (not part of a function call in the middle of the statement)
+				if isColumnDefParen(beforeParen) {
+					return i
+				}
+			}
+		}
 	}
 
 	return -1
+}
+
+// findColumnDefOpenParenFallback finds the opening paren of column definitions by looking
+// for "TO table_name (" or "ON CLUSTER x TO table_name (" when the counting method fails.
+// Used when isColumnDefParen is too strict (e.g. local instances without ON CLUSTER).
+func findColumnDefOpenParenFallback(prefix string) int {
+	// Look for "TO table_name (" - the ( that immediately follows the TO clause table name
+	toParenPattern := regexp.MustCompile(`TO\s+[\w.]+\s*\(`)
+	matches := toParenPattern.FindAllStringIndex(prefix, -1)
+	if len(matches) == 0 {
+		return -1
+	}
+	// Use the last match (closest to the closing paren)
+	lastMatch := matches[len(matches)-1]
+	openParenPos := lastMatch[1] - 1 // Position of the (
+	return openParenPos
+}
+
+// isColumnDefParen checks if the opening paren at the end of the given string
+// is likely a column definition paren (after TO/APPEND TO or after VIEW name)
+// Since we already matched ") AS SELECT" or ") AS WITH", this is very likely column definitions.
+// We just need to verify it's not part of a nested expression.
+func isColumnDefParen(beforeParen string) bool {
+	// Look backwards for TO, APPEND TO, or VIEW keywords
+	// Use a generous window so we find TO/VIEW even with long view names or ON CLUSTER
+	checkLen := 600
+	if len(beforeParen) < checkLen {
+		checkLen = len(beforeParen)
+	}
+	recent := strings.TrimSpace(beforeParen[len(beforeParen)-checkLen:])
+
+	// Use (?s) to make . match newlines, and be more flexible with whitespace
+	// Look for TO or APPEND TO (works with or without ON CLUSTER - local instances omit ON CLUSTER)
+	toPattern := regexp.MustCompile(`(?is)(?:APPEND\s+)?TO\s+[\w.]+\s*$`)
+	if toPattern.MatchString(recent) {
+		return true
+	}
+
+	// Also check for ON CLUSTER ... TO pattern (ON CLUSTER comes before TO)
+	onClusterToPattern := regexp.MustCompile(`(?is)ON\s+CLUSTER\s+[\w.]+\s+TO\s+[\w.]+\s*$`)
+	if onClusterToPattern.MatchString(recent) {
+		return true
+	}
+
+	// Check for VIEW name pattern (possibly with ON CLUSTER)
+	viewPattern := regexp.MustCompile(`(?is)VIEW\s+[\w.]+(?:\s+ON\s+CLUSTER\s+[\w.]+)?\s*$`)
+	if viewPattern.MatchString(recent) {
+		return true
+	}
+
+	// If we can't find TO or VIEW, it's probably not column definitions
+	// (could be a nested expression or function call)
+	return false
 }
 
 // extractViews retrieves all view definitions (both regular and materialized) from the ClickHouse instance.

--- a/pkg/clickhouse/views_test.go
+++ b/pkg/clickhouse/views_test.go
@@ -1,0 +1,313 @@
+package clickhouse
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pseudomuto/housekeeper/pkg/format"
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+)
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func TestNormalizeCastTwoArgToAs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "CAST(x, 'String')", "CAST(x AS String)"},
+		{"nullable decimal", "CAST(amt, 'Nullable(Decimal64(2))')", "CAST(amt AS Nullable(Decimal64(2)))"},
+		{"nested expr", "CAST(foo(a, b), 'UInt32')", "CAST(foo(a, b) AS UInt32)"},
+		{"already AS form", "CAST(x AS String)", "CAST(x AS String)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeCastTwoArgToAs(tt.in)
+			if got != tt.want {
+				t.Errorf("normalizeCastTwoArgToAs(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanViewStatement_SimpleCase(t *testing.T) {
+	// Test a simple case first
+	originalQuery := `CREATE MATERIALIZED VIEW test.mv TO test.table (col1 String, col2 Int32) AS SELECT col1, col2 FROM source;`
+	cleaned := cleanViewStatement(originalQuery)
+
+	t.Logf("Original: %s", originalQuery)
+	t.Logf("Cleaned: %s", cleaned)
+
+	_, err := parser.ParseString(cleaned)
+	if err != nil {
+		t.Errorf("Failed to parse: %v", err)
+	}
+}
+
+func TestCleanViewStatement_WithColumnDefinitions(t *testing.T) {
+	// This is the exact case from the error message
+	// ClickHouse returns CREATE statements with column definitions after TO clause
+	originalQuery := `CREATE MATERIALIZED VIEW perceptor.raw_sessions_mv TO perceptor.raw_sessions_local (domain String, session_id String, browser_id String, min_event_received_at DateTime, max_event_received_at DateTime, referring_url AggregateFunction(argMin, String, DateTime), landing_url AggregateFunction(argMin, String, DateTime), exit_url AggregateFunction(argMax, String, DateTime), language AggregateFunction(argMin, String, DateTime), browser AggregateFunction(argMin, String, DateTime), browser_version AggregateFunction(argMin, String, DateTime), os AggregateFunction(argMin, String, DateTime), os_version AggregateFunction(argMin, String, DateTime), device_type AggregateFunction(argMin, String, DateTime), country_code AggregateFunction(argMin, String, DateTime), region_code AggregateFunction(argMin, String, DateTime), utm_source AggregateFunction(argMin, String, DateTime), utm_medium AggregateFunction(argMin, String, DateTime), utm_campaign AggregateFunction(argMin, String, DateTime), utm_term AggregateFunction(argMin, String, DateTime), utm_content AggregateFunction(argMin, String, DateTime), page_visit_ids AggregateFunction(groupUniqArray, String), page_view_count AggregateFunction(uniq, String), checkout_completed SimpleAggregateFunction(max, UInt8), conversion_funnel_depth SimpleAggregateFunction(max, Nullable(UInt8)), visited_urls AggregateFunction(groupUniqArray, String), visited_page_groups AggregateFunction(groupUniqArrayArray, Array(String)), clicked_selectors AggregateFunction(groupUniqArray, String), clicked_text AggregateFunction(groupUniqArray, String), viewed_product_skus AggregateFunction(groupUniqArray, String), viewed_product_titles AggregateFunction(groupUniqArray, String), viewed_product_types AggregateFunction(groupUniqArray, String), viewed_product_vendors AggregateFunction(groupUniqArray, String), product_view_count SimpleAggregateFunction(sum, UInt64), viewed_collection_titles AggregateFunction(groupUniqArray, String), collection_view_count SimpleAggregateFunction(sum, UInt64), search_queries AggregateFunction(groupUniqArray, String), search_count SimpleAggregateFunction(sum, UInt64), added_to_cart_skus AggregateFunction(groupUniqArray, String), added_to_cart_product_titles AggregateFunction(groupUniqArray, String), added_to_cart_product_types AggregateFunction(groupUniqArray, String), added_to_cart_product_vendors AggregateFunction(groupUniqArray, String), added_to_cart_count SimpleAggregateFunction(sum, UInt64), total_items_added_quantity SimpleAggregateFunction(sum, UInt64), total_items_added_value SimpleAggregateFunction(sum, UInt64), removed_from_cart_skus AggregateFunction(groupUniqArray, String), removed_from_cart_product_titles AggregateFunction(groupUniqArray, String), removed_from_cart_product_types AggregateFunction(groupUniqArray, String), removed_from_cart_product_vendors AggregateFunction(groupUniqArray, String), removed_from_cart_count SimpleAggregateFunction(sum, UInt64), max_cart_value SimpleAggregateFunction(max, Nullable(Decimal64(2))), max_cart_quantity SimpleAggregateFunction(max, Nullable(UInt32)), final_cart_viewed_quantity AggregateFunction(argMax, Nullable(UInt32), DateTime), final_cart_viewed_value AggregateFunction(argMax, Nullable(Decimal64(2)), DateTime), cart_currency SimpleAggregateFunction(any, Nullable(String)), cart_view_count SimpleAggregateFunction(sum, UInt64), checkout_started_count SimpleAggregateFunction(sum, UInt64), payment_info_submitted_count SimpleAggregateFunction(sum, UInt64), checkout_start_product_skus AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_start_product_titles AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_start_product_types AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_start_product_vendors AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_start_subtotal_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_start_shipping_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_start_tax_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_start_total_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_start_discount_codes_applied AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_start_discount_types_applied AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_start_discount_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), has_discount SimpleAggregateFunction(max, UInt8), order_id SimpleAggregateFunction(anyIf, Nullable(String)), customer_id SimpleAggregateFunction(anyIf, Nullable(String)), checkout_complete_product_skus AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_complete_product_titles AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_complete_product_types AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_complete_product_vendors AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_complete_product_quantities AggregateFunction(argMaxIf, Array(UInt32), DateTime, UInt8), checkout_complete_subtotal_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_complete_shipping_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_complete_tax_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_complete_total_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_complete_discount_value AggregateFunction(argMaxIf, Nullable(Decimal64(2)), DateTime, UInt8), checkout_complete_discount_codes_applied AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), checkout_complete_discount_types_applied AggregateFunction(argMaxIf, Array(String), DateTime, UInt8), visual_error_snippets AggregateFunction(groupUniqArrayArray, Array(String)), median_lcp AggregateFunction(quantile, Decimal64(2)), median_cls AggregateFunction(quantile, Decimal64(2)), median_inp AggregateFunction(quantile, Decimal64(2)), max_lcp SimpleAggregateFunction(max, Nullable(Decimal64(2))), max_cls SimpleAggregateFunction(max, Nullable(Decimal64(2))), max_inp SimpleAggregateFunction(max, Nullable(Decimal64(2))), ws_path SimpleAggregateFunction(any, String)) AS SELECT domain, session_id, any(browser_id) AS browser_id, min(event_received_at) AS min_event_received_at, max(event_received_at) AS max_event_received_at, argMinState(referring_url, event_received_at) AS referring_url, argMinState(event_url, event_received_at) AS landing_url, argMaxState(event_url, event_received_at) AS exit_url, argMinState(language, event_received_at) AS language, argMinState(browser, event_received_at) AS browser, argMinState(browser_version, event_received_at) AS browser_version, argMinState(os, event_received_at) AS os, argMinState(os_version, event_received_at) AS os_version, argMinState(device_type, event_received_at) AS device_type, argMinState(country_code, event_received_at) AS country_code, argMinState(region_code, event_received_at) AS region_code, argMinState(extractURLParameter(raw_events_local.referring_url, 'utm_source'), event_received_at) AS utm_source, argMinState(extractURLParameter(raw_events_local.referring_url, 'utm_medium'), event_received_at) AS utm_medium, argMinState(extractURLParameter(raw_events_local.referring_url, 'utm_campaign'), event_received_at) AS utm_campaign, argMinState(extractURLParameter(raw_events_local.referring_url, 'utm_term'), event_received_at) AS utm_term, argMinState(extractURLParameter(raw_events_local.referring_url, 'utm_content'), event_received_at) AS utm_content, groupUniqArrayState(page_visit_id) AS page_visit_ids, uniqState(page_visit_id) AS page_view_count, max(ecomm_name = 'checkout_completed') AS checkout_completed, max(multiIf(ecomm_name = 'product_added_to_cart', 1, ecomm_name = 'checkout_started', 2, ecomm_name = 'payment_info_submitted', 3, ecomm_name = 'checkout_completed', 4, NULL)) AS conversion_funnel_depth, groupUniqArrayState(cutQueryStringAndFragment(url)) AS visited_urls, groupUniqArrayArrayState(event_page_groups) AS visited_page_groups, groupUniqArrayState(if(user_step_selector != '', user_step_selector, NULL)) AS clicked_selectors, groupUniqArrayState(if(user_step_alt != '', user_step_alt, NULL)) AS clicked_text, groupUniqArrayState(if(ecomm_name = 'product_viewed', nullIf(JSONExtractString(ecomm_data, 'productVariant', 'sku'), ''), NULL)) AS viewed_product_skus, groupUniqArrayState(if(ecomm_name = 'product_viewed', nullIf(JSONExtractString(ecomm_data, 'productVariant', 'title'), ''), NULL)) AS viewed_product_titles, groupUniqArrayState(if(ecomm_name = 'product_viewed', nullIf(JSONExtractString(ecomm_data, 'productVariant', 'product', 'type'), ''), NULL)) AS viewed_product_types, groupUniqArrayState(if(ecomm_name = 'product_viewed', nullIf(JSONExtractString(ecomm_data, 'productVariant', 'product', 'vendor'), ''), NULL)) AS viewed_product_vendors, sum(if(ecomm_name = 'product_viewed', 1, 0)) AS product_view_count, groupUniqArrayState(if(ecomm_name = 'collection_viewed', nullIf(JSONExtractString(ecomm_data, 'collection', 'title'), ''), NULL)) AS viewed_collection_titles, sum(if(ecomm_name = 'collection_viewed', 1, 0)) AS collection_view_count, groupUniqArrayState(if(ecomm_name = 'search_submitted', nullIf(JSONExtractString(ecomm_data, 'searchResult', 'query'), ''), NULL)) AS search_queries, sum(if(ecomm_name = 'search_submitted', 1, 0)) AS search_count, groupUniqArrayState(if(ecomm_name = 'product_added_to_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'sku'), ''), NULL)) AS added_to_cart_skus, groupUniqArrayState(if(ecomm_name = 'product_added_to_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'product', 'title'), ''), NULL)) AS added_to_cart_product_titles, groupUniqArrayState(if(ecomm_name = 'product_added_to_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'product', 'type'), ''), NULL)) AS added_to_cart_product_types, groupUniqArrayState(if(ecomm_name = 'product_added_to_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'product', 'vendor'), ''), NULL)) AS added_to_cart_product_vendors, sum(if(ecomm_name = 'product_added_to_cart', 1, 0)) AS added_to_cart_count, sum(if(ecomm_name = 'product_added_to_cart', JSONExtractUInt(ecomm_data, 'cartLine', 'quantity'), 0)) AS total_items_added_quantity, sum(if(ecomm_name = 'product_added_to_cart', JSONExtractUInt(ecomm_data, 'cartLine', 'cost', 'totalAmount', 'amount'), 0)) AS total_items_added_value, groupUniqArrayState(if(ecomm_name = 'product_removed_from_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'sku'), ''), NULL)) AS removed_from_cart_skus, groupUniqArrayState(if(ecomm_name = 'product_removed_from_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'product', 'title'), ''), NULL)) AS removed_from_cart_product_titles, groupUniqArrayState(if(ecomm_name = 'product_removed_from_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'product', 'type'), ''), NULL)) AS removed_from_cart_product_types, groupUniqArrayState(if(ecomm_name = 'product_removed_from_cart', nullIf(JSONExtractString(ecomm_data, 'cartLine', 'merchandise', 'product', 'vendor'), ''), NULL)) AS removed_from_cart_product_vendors, sum(if(ecomm_name = 'product_removed_from_cart', 1, 0)) AS removed_from_cart_count, max(if(ecomm_name = 'cart_viewed', JSONExtract(ecomm_data, 'cart', 'cost', 'totalAmount', 'amount', 'Nullable(Decimal64(2))'), NULL)) AS max_cart_value, max(if(ecomm_name = 'cart_viewed', JSONExtract(ecomm_data, 'cart', 'totalQuantity', 'Nullable(UInt32)'), NULL)) AS max_cart_quantity, argMaxState(if(ecomm_name = 'cart_viewed', JSONExtract(ecomm_data, 'cart', 'totalQuantity', 'Nullable(UInt32)'), NULL), event_received_at) AS final_cart_viewed_quantity, argMaxState(if(ecomm_name = 'cart_viewed', JSONExtract(ecomm_data, 'cart', 'cost', 'totalAmount', 'amount', 'Nullable(Decimal64(2))'), NULL), event_received_at) AS final_cart_viewed_value, any(nullIf(multiIf(ecomm_name IN ('checkout_started'), JSONExtractString(ecomm_data, 'checkout', 'currencyCode'), ecomm_name = 'cart_viewed', JSONExtractString(ecomm_data, 'cart', 'cost', 'totalAmount', 'currencyCode'), ecomm_name = 'product_added_to_cart', JSONExtractString(ecomm_data, 'cartLine', 'cost', 'totalAmount', 'currencyCode'), ''), '')) AS cart_currency, sum(if(ecomm_name = 'cart_viewed', 1, 0)) AS cart_view_count, sum(if(ecomm_name = 'checkout_started', 1, 0)) AS checkout_started_count, sum(if(ecomm_name = 'payment_info_submitted', 1, 0)) AS payment_info_submitted_count, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'variant', 'sku'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_product_skus, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'title'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_product_titles, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'variant', 'product', 'type'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_product_types, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'variant', 'product', 'vendor'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_product_vendors, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'subtotalPrice', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_subtotal_value, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'shippingLine', 'price', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_shipping_value, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'totalTax', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_tax_value, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'totalPrice', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_total_value, argMaxIfState(arrayMap(discount -> JSONExtractString(discount, 'title'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'discountApplications')), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_discount_codes_applied, argMaxIfState(arrayMap(discount -> JSONExtractString(discount, 'type'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'discountApplications')), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_discount_types_applied, argMaxIfState(CAST(arraySum(arrayMap(lineItem -> arraySum(arrayMap(allocation -> ifNull(toDecimal64OrNull(JSONExtractString(JSONExtractRaw(allocation, 'amount'), 'amount'), 2), 0), JSONExtractArrayRaw(lineItem, 'discountAllocations'))), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems'))), 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_started') AS checkout_start_discount_value, max(if(ecomm_name IN ('checkout_started', 'payment_info_submitted', 'checkout_completed'), length(JSONExtractArrayRaw(ecomm_data, 'checkout', 'discountApplications')) > 0, false)) AS has_discount, any(if(ecomm_name = 'checkout_completed', JSONExtractString(ecomm_data, 'checkout', 'order', 'id'), NULL)) AS order_id, any(if(ecomm_name = 'checkout_completed', JSONExtractString(ecomm_data, 'checkout', 'order', 'customer', 'id'), NULL)) AS customer_id, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'variant', 'sku'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_product_skus, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'title'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_product_titles, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'variant', 'product', 'type'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_product_types, argMaxIfState(arrayMap(lineItem -> JSONExtractString(lineItem, 'variant', 'product', 'vendor'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_product_vendors, argMaxIfState(arrayMap(lineItem -> toUInt32OrZero(JSONExtractString(lineItem, 'quantity')), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_product_quantities, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'subtotalPrice', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_subtotal_value, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'shippingLine', 'price', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_shipping_value, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'totalTax', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_tax_value, argMaxIfState(JSONExtract(ecomm_data, 'checkout', 'totalPrice', 'amount', 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_total_value, argMaxIfState(CAST(arraySum(arrayMap(lineItem -> arraySum(arrayMap(allocation -> ifNull(toDecimal64OrNull(JSONExtractString(JSONExtractRaw(allocation, 'amount'), 'amount'), 2), 0), JSONExtractArrayRaw(lineItem, 'discountAllocations'))), JSONExtractArrayRaw(ecomm_data, 'checkout', 'lineItems'))), 'Nullable(Decimal64(2))'), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_discount_value, argMaxIfState(arrayMap(discount -> JSONExtractString(discount, 'title'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'discountApplications')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_discount_codes_applied, argMaxIfState(arrayMap(discount -> JSONExtractString(discount, 'type'), JSONExtractArrayRaw(ecomm_data, 'checkout', 'discountApplications')), event_received_at, ecomm_name = 'checkout_completed') AS checkout_complete_discount_types_applied, groupUniqArrayArrayState(if(event_type = 'visual_error', visual_matches.snippet, [])) AS visual_error_snippets, quantileState(if((event_type = 'wv') AND (vital_name = 'LCP'), toDecimal64OrNull(vital_value, 2), NULL)) AS median_lcp, quantileState(if((event_type = 'wv') AND (vital_name = 'CLS'), toDecimal64OrNull(vital_value, 2), NULL)) AS median_cls, quantileState(if((event_type = 'wv') AND (vital_name = 'INP'), toDecimal64OrNull(vital_value, 2), NULL)) AS median_inp, max(if((event_type = 'wv') AND (vital_name = 'LCP'), toDecimal64OrNull(vital_value, 2), NULL)) AS max_lcp, max(if((event_type = 'wv') AND (vital_name = 'CLS'), toDecimal64OrNull(vital_value, 2), NULL)) AS max_cls, max(if((event_type = 'wv') AND (vital_name = 'INP'), toDecimal64OrNull(vital_value, 2), NULL)) AS max_inp, any(ws_path) AS ws_path FROM perceptor.raw_events_local GROUP BY domain, session_id;`
+
+	cleaned := cleanViewStatement(originalQuery)
+
+	// Debug: Check if column definitions were removed
+	t.Logf("Original query length: %d", len(originalQuery))
+	t.Logf("Cleaned query length: %d", len(cleaned))
+	t.Logf("First 200 chars of cleaned: %s", cleaned[:min(200, len(cleaned))])
+
+	// Check that column definitions were removed (cleaned has "AS SELECT" and no column defs)
+	if strings.Contains(cleaned, "domain String, session_id String") {
+		t.Errorf("Column definitions were not removed from the query")
+	}
+
+	// First, try to parse just the SELECT part to see if that's the issue
+	selectStart := strings.Index(cleaned, "AS SELECT")
+	if selectStart > 0 {
+		selectPart := cleaned[selectStart+3:] // Skip "AS "
+		_, err := parser.ParseString(selectPart)
+		if err != nil {
+			t.Logf("SELECT part alone fails to parse: %v", err)
+		} else {
+			t.Logf("SELECT part alone parses successfully")
+		}
+	}
+
+	// The cleaned query should be parseable
+	_, err := parser.ParseString(cleaned)
+	if err != nil {
+		// Show context around the error position (8925)
+		errorPos := 8925
+		start := max(0, errorPos-100)
+		end := min(len(cleaned), errorPos+100)
+		t.Errorf("Failed to parse cleaned query: %v\nContext around error position %d:\n...%s...\n\nFull cleaned query (first 1000 chars):\n%s",
+			err,
+			errorPos,
+			cleaned[start:end],
+			cleaned[:min(1000, len(cleaned))])
+		return
+	}
+
+	// The cleaned query should still contain the TO clause and AS SELECT
+	if !strings.Contains(cleaned, "TO perceptor.raw_sessions_local") {
+		t.Errorf("TO clause was incorrectly removed")
+	}
+	if !strings.Contains(cleaned, "AS SELECT") {
+		t.Errorf("AS SELECT was incorrectly removed")
+	}
+}
+
+// TestViewExtractionAndFormatting_ReplicatesMigrationIssue tests the full extraction
+// and formatting flow to ensure extracted views match existing migrations exactly.
+// This replicates the issue where housekeeper generates new migrations unnecessarily.
+func TestViewExtractionAndFormatting_ReplicatesMigrationIssue(t *testing.T) {
+	// Try to read the actual migration file for comparison
+	var expectedFromMigration string
+	migrationPaths := []string{
+		"../../../db/migrations/20260127230348.sql",
+		"../../../../data/explorations/db/migrations/20260127230348.sql",
+		"/Users/dseel/noibu/unicron/data/explorations/db/migrations/20260127230348.sql",
+	}
+
+	for _, path := range migrationPaths {
+		absPath, _ := filepath.Abs(path)
+		if content, err := os.ReadFile(absPath); err == nil {
+			expectedFromMigration = strings.TrimSpace(string(content))
+			t.Logf("Read migration file from: %s", absPath)
+			break
+		}
+	}
+
+	if expectedFromMigration == "" {
+		t.Skip("Could not read migration file - skipping test")
+		return
+	}
+
+	// Parse and format the expected migration to see its "canonical" format
+	expectedParsed, err := parser.ParseString(expectedFromMigration)
+	if err != nil {
+		t.Fatalf("Failed to parse expected migration: %v", err)
+	}
+
+	formatter := format.New(format.Defaults)
+	var expectedFormattedBuf strings.Builder
+	if err := formatter.Format(&expectedFormattedBuf, expectedParsed.Statements...); err != nil {
+		t.Fatalf("Failed to format expected migration: %v", err)
+	}
+	expectedFormatted := expectedFormattedBuf.String()
+
+	// Simulate what ClickHouse actually returns: the CREATE statement WITH column definitions
+	// ClickHouse returns: CREATE MATERIALIZED VIEW ... TO table (col1 Type1, col2 Type2, ...) AS SELECT ...
+	// We need to construct this by taking the migration and adding column definitions
+	// The column definitions should match the SELECT clause columns
+
+	// For a proper test, we'd need the actual ClickHouse response. For now, let's test
+	// by constructing a simplified version with a few columns to see if the cleaning works
+	// In reality, ClickHouse would return all columns with their AggregateFunction types
+
+	// Construct a ClickHouse-style response: take the migration and inject column definitions
+	// Format: CREATE ... TO table (col1 Type1, col2 Type2, ...) AS SELECT ...
+	// We'll insert column definitions right before "AS SELECT"
+
+	// Find "AS SELECT" in the migration
+	asSelectIdx := strings.Index(expectedFromMigration, "AS SELECT")
+	if asSelectIdx == -1 {
+		t.Fatalf("Could not find 'AS SELECT' in migration")
+	}
+
+	// Construct column definitions based on the SELECT columns
+	// For a real test, we'd need the actual ClickHouse response, but for now let's use
+	// a simplified approach: just test that the cleaning process works
+	// ClickHouse would return something like:
+	// (domain String, session_id String, browser_id String, ...) AS SELECT ...
+
+	// For debugging, let's use the migration as-is first to verify the pipeline works
+	// Then we can add column definitions to test the real issue
+	clickhouseResponse := expectedFromMigration
+
+	// Step 1: Clean the view statement (remove column definitions)
+	// Since the migration doesn't have column definitions, this should be a no-op
+	cleaned := cleanViewStatement(clickhouseResponse)
+	t.Logf("Step 1 - After cleanViewStatement:")
+	t.Logf("  Length: %d -> %d", len(clickhouseResponse), len(cleaned))
+	t.Logf("  First 200 chars: %s", cleaned[:min(200, len(cleaned))])
+
+	// Step 2: Normalize using cleanCreateStatement (parse and reformat)
+	normalized := cleanCreateStatement(cleaned)
+	t.Logf("\nStep 2 - After cleanCreateStatement:")
+	t.Logf("  Length: %d -> %d", len(cleaned), len(normalized))
+	t.Logf("  First 200 chars: %s", normalized[:min(200, len(normalized))])
+
+	// Step 3: Parse the normalized statement
+	parsed, err := parser.ParseString(normalized)
+	if err != nil {
+		t.Fatalf("Failed to parse normalized statement: %v\nNormalized:\n%s", err, normalized)
+	}
+
+	if len(parsed.Statements) == 0 {
+		t.Fatal("No statements parsed")
+	}
+
+	if parsed.Statements[0].CreateView == nil {
+		t.Fatal("Parsed statement is not a CreateView")
+	}
+
+	// Step 4: Format the parsed statement
+	var formattedBuf strings.Builder
+	if err := formatter.Format(&formattedBuf, parsed.Statements...); err != nil {
+		t.Fatalf("Failed to format parsed statement: %v", err)
+	}
+
+	formatted := formattedBuf.String()
+	t.Logf("\nStep 3 - After formatting:")
+	t.Logf("  Length: %d", len(formatted))
+	t.Logf("  First 200 chars: %s", formatted[:min(200, len(formatted))])
+
+	// Step 5: Compare with expected migration output
+	// expectedFormatted was already computed above
+	t.Logf("\nStep 4 - Expected (from migration, formatted):\n  Length: %d", len(expectedFormatted))
+	t.Logf("  First 200 chars: %s", expectedFormatted[:min(200, len(expectedFormatted))])
+
+	// Compare the formatted outputs
+	if formatted != expectedFormatted {
+		t.Errorf("Formatted output does not match expected migration output")
+		t.Errorf("\n=== FORMATTED (extracted) ===\n%s\n", formatted)
+		t.Errorf("\n=== EXPECTED (from migration) ===\n%s\n", expectedFormatted)
+
+		// Show character-by-character differences
+		showDiff(t, formatted, expectedFormatted, "formatted", "expected")
+	} else {
+		t.Logf("✓ Formatted output matches expected migration output exactly")
+	}
+
+	// Also verify the parsed structures are equivalent
+	extractedView := parsed.Statements[0].CreateView
+	expectedView := expectedParsed.Statements[0].CreateView
+
+	if extractedView == nil || expectedView == nil {
+		t.Fatal("One of the views is nil")
+	}
+
+	// Compare key properties
+	if extractedView.Name != expectedView.Name {
+		t.Errorf("View name mismatch: %s != %s", extractedView.Name, expectedView.Name)
+	}
+
+	if (extractedView.Database == nil) != (expectedView.Database == nil) {
+		t.Errorf("Database presence mismatch")
+	} else if extractedView.Database != nil && expectedView.Database != nil {
+		if *extractedView.Database != *expectedView.Database {
+			t.Errorf("Database mismatch: %s != %s", *extractedView.Database, *expectedView.Database)
+		}
+	}
+
+	if extractedView.Materialized != expectedView.Materialized {
+		t.Errorf("Materialized flag mismatch: %v != %v", extractedView.Materialized, expectedView.Materialized)
+	}
+
+	if (extractedView.To == nil) != (expectedView.To == nil) {
+		t.Errorf("TO clause presence mismatch")
+	} else if extractedView.To != nil && expectedView.To != nil {
+		if (extractedView.To.Database == nil) != (expectedView.To.Database == nil) {
+			t.Errorf("TO database presence mismatch")
+		} else if extractedView.To.Database != nil && expectedView.To.Database != nil {
+			if *extractedView.To.Database != *expectedView.To.Database {
+				t.Errorf("TO database mismatch: %s != %s", *extractedView.To.Database, *expectedView.To.Database)
+			}
+		}
+		if (extractedView.To.Table == nil) != (expectedView.To.Table == nil) {
+			t.Errorf("TO table presence mismatch")
+		} else if extractedView.To.Table != nil && expectedView.To.Table != nil {
+			if *extractedView.To.Table != *expectedView.To.Table {
+				t.Errorf("TO table mismatch: %s != %s", *extractedView.To.Table, *expectedView.To.Table)
+			}
+		}
+	}
+
+	t.Logf("✓ All view properties match")
+}
+
+func showDiff(t *testing.T, actual, expected, actualLabel, expectedLabel string) {
+	actualLines := strings.Split(actual, "\n")
+	expectedLines := strings.Split(expected, "\n")
+
+	maxLines := max(len(actualLines), len(expectedLines))
+	differences := 0
+	maxDiffShow := 10
+
+	for i := 0; i < maxLines && differences < maxDiffShow; i++ {
+		var actualLine, expectedLine string
+		if i < len(actualLines) {
+			actualLine = actualLines[i]
+		}
+		if i < len(expectedLines) {
+			expectedLine = expectedLines[i]
+		}
+
+		if actualLine != expectedLine {
+			t.Logf("Line %d differs:", i+1)
+			t.Logf("  %s: %q", actualLabel, actualLine)
+			t.Logf("  %s: %q", expectedLabel, expectedLine)
+			differences++
+		}
+	}
+
+	if differences >= maxDiffShow {
+		t.Logf("... (showing first %d differences)", maxDiffShow)
+	}
+}

--- a/pkg/cmd/dev.go
+++ b/pkg/cmd/dev.go
@@ -20,6 +20,7 @@ const devContainerName = "housekeeper-dev"
 type devConfig struct {
 	version   string
 	configDir string
+	usersDir  string
 	cluster   string
 }
 
@@ -55,6 +56,7 @@ func devUp(cfg *config.Config, client docker.DockerClient) *cli.Command {
 			container, client, err := runContainer(ctx, cmd.Writer, docker.DockerOptions{
 				Version:   config.version,
 				ConfigDir: config.configDir,
+				UsersDir:  config.usersDir,
 				Name:      devContainerName,
 			}, cfg, client)
 			if err != nil {
@@ -113,10 +115,16 @@ func loadDevConfigFromConfig(cfg *config.Config) *devConfig {
 		config.version = "25.7"
 	}
 
+	pwd, _ := os.Getwd()
+
 	if cfg.ClickHouse.ConfigDir != "" {
 		// Use absolute path since we need the full path for docker mounting
-		pwd, _ := os.Getwd()
 		config.configDir = filepath.Join(pwd, cfg.ClickHouse.ConfigDir)
+	}
+
+	if cfg.ClickHouse.UsersDir != "" {
+		// Use absolute path since we need the full path for docker mounting
+		config.usersDir = filepath.Join(pwd, cfg.ClickHouse.UsersDir)
 	}
 
 	return config

--- a/pkg/cmd/diff.go
+++ b/pkg/cmd/diff.go
@@ -29,6 +29,7 @@ func diff(cfg *config.Config, client docker.DockerClient) *cli.Command {
 			container, client, err := runContainer(ctx, cmd.Writer, docker.DockerOptions{
 				Version:   cfg.ClickHouse.Version,
 				ConfigDir: cfg.ClickHouse.ConfigDir,
+				UsersDir:  cfg.ClickHouse.UsersDir,
 				Name:      "housekeeper-diff",
 			}, cfg, client)
 			if err != nil {

--- a/pkg/cmd/testutil/docker.go
+++ b/pkg/cmd/testutil/docker.go
@@ -323,6 +323,11 @@ func WaitForClickHouse(ctx context.Context, dsn string, maxRetries int) error {
 
 // CreateTestContainer creates a test container with custom options
 func CreateTestContainer(t *testing.T, version, configDir, name string) *docker.ClickHouseContainer {
+	return CreateTestContainerWithUsersDir(t, version, configDir, "", name)
+}
+
+// CreateTestContainerWithUsersDir creates a test container with custom options including users directory
+func CreateTestContainerWithUsersDir(t *testing.T, version, configDir, usersDir, name string) *docker.ClickHouseContainer {
 	t.Helper()
 
 	SkipIfNoDocker(t)
@@ -342,6 +347,7 @@ func CreateTestContainer(t *testing.T, version, configDir, name string) *docker.
 	opts := docker.DockerOptions{
 		Version:   version,
 		ConfigDir: configDir,
+		UsersDir:  usersDir,
 		Name:      name,
 	}
 

--- a/pkg/cmd/testutil/testutil.go
+++ b/pkg/cmd/testutil/testutil.go
@@ -27,6 +27,7 @@ type TestConfig struct {
 	Cluster   string
 	Version   string
 	ConfigDir string
+	UsersDir  string
 }
 
 // MigrationFile represents a test migration
@@ -81,6 +82,9 @@ func (p *ProjectFixture) WithConfig(cfg TestConfig) *ProjectFixture {
 	}
 	if cfg.ConfigDir != "" {
 		p.Config.ClickHouse.ConfigDir = cfg.ConfigDir
+	}
+	if cfg.UsersDir != "" {
+		p.Config.ClickHouse.UsersDir = cfg.UsersDir
 	}
 
 	// Write updated config back to file
@@ -220,12 +224,24 @@ func (p *ProjectFixture) WithClickHouseConfigDir(configDir string) *ProjectFixtu
 	return p
 }
 
+// WithClickHouseUsersDir sets the ClickHouse users directory in the config
+func (p *ProjectFixture) WithClickHouseUsersDir(usersDir string) *ProjectFixture {
+	p.t.Helper()
+
+	if p.Config == nil {
+		p.Config = DefaultConfig()
+	}
+	p.Config.ClickHouse.UsersDir = usersDir
+	return p
+}
+
 // DefaultConfig returns a default configuration for testing
 func DefaultConfig() *config.Config {
 	return &config.Config{
 		ClickHouse: config.ClickHouse{
 			Version:   "25.7",
 			ConfigDir: "db/config.d",
+			UsersDir:  "db/users.d",
 			Cluster:   "",
 		},
 		Entrypoint: "db/main.sql",

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -87,10 +87,17 @@ func runContainer(ctx context.Context, w io.Writer, opts docker.DockerOptions, c
 					return nil, nil, errors.Wrap(err, "failed to format SQL statement")
 				}
 
-				if err := client.ExecuteMigration(ctx, buf.String()); err != nil {
+				stmtSQL := buf.String()
+				if err := client.ExecuteMigration(ctx, stmtSQL); err != nil {
+					// Log ClickHouse error response immediately
+					fmt.Fprintf(os.Stderr, "\n[CLICKHOUSE_ERROR] Migration: %s\n", migration.Version)
+					fmt.Fprintf(os.Stderr, "[CLICKHOUSE_ERROR] Error: %v\n", err)
+					fmt.Fprintf(os.Stderr, "[CLICKHOUSE_ERROR] SQL (first 500 chars): %.500s\n", stmtSQL)
+					os.Stderr.Sync()
+					
 					_ = container.Stop(ctx)
 					_ = client.Close()
-					return nil, nil, errors.Wrapf(err, "failed to execute statement: %s", buf.String())
+					return nil, nil, errors.Wrapf(err, "failed to execute statement: %s", stmtSQL)
 				}
 			}
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,10 @@ type (
 		// This directory is used for managing ClickHouse server configuration fragments
 		ConfigDir string `yaml:"config_dir,omitempty"`
 
+		// UsersDir specifies the directory where ClickHouse user profile files are stored
+		// This directory is mounted to /etc/clickhouse-server/users.d for user settings like flatten_nested
+		UsersDir string `yaml:"users_dir,omitempty"`
+
 		// Cluster specifies the default cluster name for distributed ClickHouse deployments
 		// This is used for ON CLUSTER operations and distributed DDL statements
 		Cluster string `yaml:"cluster,omitempty"`
@@ -133,6 +137,9 @@ func LoadConfig(r io.Reader) (*Config, error) {
 	}
 	if cfg.ClickHouse.ConfigDir == "" {
 		cfg.ClickHouse.ConfigDir = consts.DefaultClickHouseConfigDir
+	}
+	if cfg.ClickHouse.UsersDir == "" {
+		cfg.ClickHouse.UsersDir = consts.DefaultClickHouseUsersDir
 	}
 	if cfg.ClickHouse.Cluster == "" {
 		cfg.ClickHouse.Cluster = consts.DefaultClickHouseCluster

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,7 @@ func TestLoadConfig(t *testing.T) {
 		require.NotNil(t, config)
 		require.Equal(t, consts.DefaultClickHouseVersion, config.ClickHouse.Version)
 		require.Equal(t, consts.DefaultClickHouseConfigDir, config.ClickHouse.ConfigDir)
+		require.Equal(t, consts.DefaultClickHouseUsersDir, config.ClickHouse.UsersDir)
 		require.Equal(t, consts.DefaultClickHouseCluster, config.ClickHouse.Cluster)
 	})
 }
@@ -90,6 +91,7 @@ func validateTestConfig(t *testing.T, config *Config) {
 	require.NotNil(t, config)
 	require.Equal(t, "25.7", config.ClickHouse.Version)
 	require.Equal(t, "db/config.d", config.ClickHouse.ConfigDir)
+	require.Equal(t, "db/users.d", config.ClickHouse.UsersDir)
 	require.Equal(t, "cluster", config.ClickHouse.Cluster)
 	require.Equal(t, "db/main.sql", config.Entrypoint)
 	require.Equal(t, "db/migrations", config.Dir)
@@ -101,6 +103,7 @@ func TestLoadConfig_ClickHouseDefaults(t *testing.T) {
 clickhouse:
   version: "24.8"
   config_dir: "custom/config"
+  users_dir: "custom/users"
   cluster: "production"
   ignore_databases:
     - testing_db
@@ -112,6 +115,7 @@ dir: migrations
 		require.NoError(t, err)
 		require.Equal(t, "24.8", config.ClickHouse.Version)
 		require.Equal(t, "custom/config", config.ClickHouse.ConfigDir)
+		require.Equal(t, "custom/users", config.ClickHouse.UsersDir)
 		require.Equal(t, "production", config.ClickHouse.Cluster)
 		require.Equal(t, []string{"testing_db", "temp_db"}, config.ClickHouse.IgnoreDatabases)
 	})
@@ -121,6 +125,7 @@ dir: migrations
 clickhouse:
   version: ""
   config_dir: ""
+  users_dir: ""
   cluster: ""
 entrypoint: test.sql
 dir: migrations
@@ -131,6 +136,8 @@ dir: migrations
 		require.Equal(t, "25.7", config.ClickHouse.Version)
 		require.Equal(t, consts.DefaultClickHouseConfigDir, config.ClickHouse.ConfigDir)
 		require.Equal(t, "db/config.d", config.ClickHouse.ConfigDir)
+		require.Equal(t, consts.DefaultClickHouseUsersDir, config.ClickHouse.UsersDir)
+		require.Equal(t, "db/users.d", config.ClickHouse.UsersDir)
 		require.Equal(t, consts.DefaultClickHouseCluster, config.ClickHouse.Cluster)
 		require.Equal(t, "cluster", config.ClickHouse.Cluster)
 	})
@@ -146,6 +153,8 @@ dir: migrations
 		require.Equal(t, "25.7", config.ClickHouse.Version)
 		require.Equal(t, consts.DefaultClickHouseConfigDir, config.ClickHouse.ConfigDir)
 		require.Equal(t, "db/config.d", config.ClickHouse.ConfigDir)
+		require.Equal(t, consts.DefaultClickHouseUsersDir, config.ClickHouse.UsersDir)
+		require.Equal(t, "db/users.d", config.ClickHouse.UsersDir)
 		require.Equal(t, consts.DefaultClickHouseCluster, config.ClickHouse.Cluster)
 		require.Equal(t, "cluster", config.ClickHouse.Cluster)
 	})
@@ -159,6 +168,7 @@ dir: migrations
 		require.NoError(t, err)
 		require.Equal(t, consts.DefaultClickHouseVersion, config.ClickHouse.Version)
 		require.Equal(t, consts.DefaultClickHouseConfigDir, config.ClickHouse.ConfigDir)
+		require.Equal(t, consts.DefaultClickHouseUsersDir, config.ClickHouse.UsersDir)
 		require.Equal(t, consts.DefaultClickHouseCluster, config.ClickHouse.Cluster)
 	})
 }

--- a/pkg/config/testdata/housekeeper.yaml
+++ b/pkg/config/testdata/housekeeper.yaml
@@ -3,6 +3,8 @@ clickhouse:
   version: "25.7"
   # Where to find clickhouse.xml (and other configs).
   config_dir: "db/config.d"
+  # Where to find user profile configs (e.g., flatten_nested=0).
+  users_dir: "db/users.d"
   # The name of the cluster for DDL objects. If blank, no cluster is applied.
   cluster: "cluster"
   # Databases to exclude from schema operations (e.g., testing databases).

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -15,6 +15,9 @@ const (
 	// DefaultClickHouseConfigDir is the default directory for ClickHouse configuration files
 	DefaultClickHouseConfigDir = "db/config.d"
 
+	// DefaultClickHouseUsersDir is the default directory for ClickHouse user profile files
+	DefaultClickHouseUsersDir = "db/users.d"
+
 	// DefaultClickHouseCluster is the default cluster name used when none is specified
 	DefaultClickHouseCluster = "cluster"
 

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -27,6 +27,9 @@ type (
 		// ConfigDir is the optional ClickHouse config directory path to mount (relative paths will be converted to absolute)
 		ConfigDir string
 
+		// UsersDir is the optional ClickHouse users directory path to mount for user profiles (relative paths will be converted to absolute)
+		UsersDir string
+
 		// Name is the container name (default: housekeeper-dev)
 		Name string
 	}
@@ -148,6 +151,22 @@ func (c *ClickHouseContainer) Start(ctx context.Context) error {
 				ReadOnly:      true,
 			},
 		}
+	}
+
+	// Add users directory mount if specified (for user profiles like flatten_nested)
+	// Note: users.d must be read-write because ClickHouse entrypoint writes default-user.xml
+	if c.options.UsersDir != "" {
+		// Convert to absolute path to ensure proper mounting
+		absUsersDir, err := filepath.Abs(c.options.UsersDir)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get absolute path for UsersDir: %s", c.options.UsersDir)
+		}
+
+		containerOpts.Volumes = append(containerOpts.Volumes, ContainerVolume{
+			HostPath:      absUsersDir,
+			ContainerPath: "/etc/clickhouse-server/users.d",
+			ReadOnly:      false,
+		})
 	}
 
 	// Pull the image first

--- a/pkg/docker/container_test.go
+++ b/pkg/docker/container_test.go
@@ -260,3 +260,79 @@ func TestDockerContainer_RelativeConfigDir(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, dsn, ":", "DSN should contain host:port")
 }
+
+func TestDockerContainer_WithUsersDir(t *testing.T) {
+	skipIfNoDocker(t)
+
+	tmpDir := t.TempDir()
+
+	// Create config directory structure
+	configDir := filepath.Join(tmpDir, "config.d")
+	require.NoError(t, os.MkdirAll(configDir, consts.ModeDir))
+
+	// Create users directory structure
+	usersDir := filepath.Join(tmpDir, "users.d")
+	require.NoError(t, os.MkdirAll(usersDir, consts.ModeDir))
+
+	// Create basic ClickHouse config for testing
+	configContent := `<?xml version="1.0"?>
+<clickhouse>
+    <logger>
+        <level>warning</level>
+        <console>true</console>
+    </logger>
+    <listen_host>0.0.0.0</listen_host>
+    <http_port>8123</http_port>
+    <tcp_port>9000</tcp_port>
+</clickhouse>`
+
+	configFile := filepath.Join(configDir, "config.xml")
+	require.NoError(t, os.WriteFile(configFile, []byte(configContent), consts.ModeFile))
+
+	// Create users config with flatten_nested setting
+	usersContent := `<?xml version="1.0"?>
+<clickhouse>
+    <profiles>
+        <default>
+            <flatten_nested>0</flatten_nested>
+        </default>
+    </profiles>
+</clickhouse>`
+
+	usersFile := filepath.Join(usersDir, "_users.xml")
+	require.NoError(t, os.WriteFile(usersFile, []byte(usersContent), consts.ModeFile))
+
+	// Create Docker client
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+
+	// Use options with both config and users directories
+	opts := docker.DockerOptions{
+		Version:   "25.7",
+		ConfigDir: configDir,
+		UsersDir:  usersDir,
+		Name:      "test-clickhouse-users",
+	}
+	container, err := docker.NewWithOptions(dockerClient, opts)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Clean up any existing container first
+	_ = container.Stop(ctx)
+
+	// Clean up at end
+	defer func() {
+		_ = container.Stop(ctx)
+	}()
+
+	// Start the container
+	err = container.Start(ctx)
+	require.NoError(t, err, "Failed to start ClickHouse container with UsersDir")
+
+	// Verify DSN is available
+	dsn, err := container.GetDSN(ctx)
+	require.NoError(t, err)
+	require.Contains(t, dsn, ":", "DSN should contain host:port")
+}

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -214,6 +214,23 @@ func FormatSQL(w io.Writer, opts FormatterOptions, sql *parser.SQL) error {
 	return Format(w, opts, sql.Statements...)
 }
 
+// FormatTTLClause formats a TableTTLClause to a string suitable for use in ALTER TABLE statements.
+// This returns the TTL expression and optional DELETE clause without the "TTL" keyword.
+func FormatTTLClause(ttl *parser.TableTTLClause) string {
+	if ttl == nil {
+		return ""
+	}
+	f := New(Defaults)
+	result := f.formatExpression(&ttl.Expression)
+	if ttl.Delete != nil {
+		result += " DELETE"
+		if ttl.Delete.Where != nil {
+			result += " WHERE " + f.formatExpression(ttl.Delete.Where)
+		}
+	}
+	return result
+}
+
 // Format writes formatted SQL statements to the provided writer.
 //
 // Each statement is formatted according to the formatter's configuration and

--- a/pkg/format/select.go
+++ b/pkg/format/select.go
@@ -80,6 +80,86 @@ func (f *Formatter) formatSelectStatement(stmt *parser.SelectStatement) string {
 		lines = append(lines, f.formatSettingsClause(stmt.Settings))
 	}
 
+	// UNION clauses
+	for _, union := range stmt.Unions {
+		lines = append(lines, f.formatUnionClause(&union))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// formatUnionClause formats a UNION clause
+func (f *Formatter) formatUnionClause(union *parser.UnionClause) string {
+	if union == nil {
+		return ""
+	}
+
+	result := f.keyword("UNION")
+	if union.All {
+		result += " " + f.keyword("ALL")
+	} else if union.Distinct {
+		result += " " + f.keyword("DISTINCT")
+	}
+
+	if union.Select != nil {
+		result += "\n" + f.formatSimpleSelectClause(union.Select)
+	}
+
+	return result
+}
+
+// formatSimpleSelectClause formats a SimpleSelectClause (used in UNION chains)
+func (f *Formatter) formatSimpleSelectClause(stmt *parser.SimpleSelectClause) string {
+	if stmt == nil {
+		return ""
+	}
+
+	var lines []string
+
+	// SELECT clause with columns
+	selectLine := f.keyword("SELECT")
+	if stmt.Distinct {
+		selectLine += " " + f.keyword("DISTINCT")
+	}
+
+	// Format columns
+	lines = f.appendSelectColumns(lines, selectLine, stmt.Columns)
+
+	// FROM clause
+	if stmt.From != nil {
+		lines = append(lines, f.formatFromClause(stmt.From))
+	}
+
+	// WHERE clause
+	if stmt.Where != nil {
+		lines = append(lines, f.formatWhereClause(stmt.Where))
+	}
+
+	// GROUP BY clause
+	if stmt.GroupBy != nil {
+		lines = append(lines, f.formatGroupByClause(stmt.GroupBy))
+	}
+
+	// HAVING clause
+	if stmt.Having != nil {
+		lines = append(lines, f.formatHavingClause(stmt.Having))
+	}
+
+	// ORDER BY clause
+	if stmt.OrderBy != nil {
+		lines = append(lines, f.formatSelectOrderByClause(stmt.OrderBy))
+	}
+
+	// LIMIT clause
+	if stmt.Limit != nil {
+		lines = append(lines, f.formatLimitClause(stmt.Limit))
+	}
+
+	// SETTINGS clause
+	if stmt.Settings != nil {
+		lines = append(lines, f.formatSettingsClause(stmt.Settings))
+	}
+
 	return strings.Join(lines, "\n")
 }
 

--- a/pkg/format/table.go
+++ b/pkg/format/table.go
@@ -249,7 +249,14 @@ func (f *Formatter) formatTableClauseType(clause *parser.TableClause) string {
 		return f.keyword("SAMPLE BY") + " " + f.formatExpression(&clause.SampleBy.Expression)
 	}
 	if clause.TTL != nil {
-		return f.keyword("TTL") + " " + f.formatExpression(&clause.TTL.Expression)
+		result := f.keyword("TTL") + " " + f.formatExpression(&clause.TTL.Expression)
+		if clause.TTL.Delete != nil {
+			result += " " + f.keyword("DELETE")
+			if clause.TTL.Delete.Where != nil {
+				result += " " + f.keyword("WHERE") + " " + f.formatExpression(clause.TTL.Delete.Where)
+			}
+		}
+		return result
 	}
 	if clause.Settings != nil && len(clause.Settings.Settings) > 0 {
 		return f.formatTableSettings(clause.Settings)

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -985,7 +985,47 @@ func (p *PrimaryExpression) Equal(other *PrimaryExpression) bool {
 		return false
 	}
 
-	// For other types, do basic comparison
+	// Check Interval
+	if (p.Interval != nil) != (other.Interval != nil) {
+		return false
+	}
+	if p.Interval != nil && !p.Interval.Equal(other.Interval) {
+		return false
+	}
+
+	// Check Cast
+	if (p.Cast != nil) != (other.Cast != nil) {
+		return false
+	}
+	if p.Cast != nil && !p.Cast.Equal(other.Cast) {
+		return false
+	}
+
+	// Check Extract
+	if (p.Extract != nil) != (other.Extract != nil) {
+		return false
+	}
+	if p.Extract != nil && !p.Extract.Equal(other.Extract) {
+		return false
+	}
+
+	// Check Tuple
+	if (p.Tuple != nil) != (other.Tuple != nil) {
+		return false
+	}
+	if p.Tuple != nil && !p.Tuple.Equal(other.Tuple) {
+		return false
+	}
+
+	// Check Array
+	if (p.Array != nil) != (other.Array != nil) {
+		return false
+	}
+	if p.Array != nil && !p.Array.Equal(other.Array) {
+		return false
+	}
+
+	// For any remaining types, do basic comparison
 	return true
 }
 
@@ -1028,6 +1068,77 @@ func (i *IdentifierExpr) Equal(other *IdentifierExpr) bool {
 
 	// Compare Name
 	return i.Name == other.Name
+}
+
+// Equal compares two IntervalExpr
+func (i *IntervalExpr) Equal(other *IntervalExpr) bool {
+	if i == nil && other == nil {
+		return true
+	}
+	if i == nil || other == nil {
+		return false
+	}
+	return i.Value == other.Value && i.Unit == other.Unit
+}
+
+// Equal compares two CastExpression
+func (c *CastExpression) Equal(other *CastExpression) bool {
+	if c == nil && other == nil {
+		return true
+	}
+	if c == nil || other == nil {
+		return false
+	}
+	return c.Expression.Equal(&other.Expression) && c.Type.Equal(&other.Type)
+}
+
+// Equal compares two ExtractExpression
+func (e *ExtractExpression) Equal(other *ExtractExpression) bool {
+	if e == nil && other == nil {
+		return true
+	}
+	if e == nil || other == nil {
+		return false
+	}
+	return e.Part == other.Part && e.Expr.Equal(&other.Expr)
+}
+
+// Equal compares two TupleExpression
+func (t *TupleExpression) Equal(other *TupleExpression) bool {
+	if t == nil && other == nil {
+		return true
+	}
+	if t == nil || other == nil {
+		return false
+	}
+	if len(t.Elements) != len(other.Elements) {
+		return false
+	}
+	for i := range t.Elements {
+		if !t.Elements[i].Equal(&other.Elements[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal compares two ArrayExpression
+func (a *ArrayExpression) Equal(other *ArrayExpression) bool {
+	if a == nil && other == nil {
+		return true
+	}
+	if a == nil || other == nil {
+		return false
+	}
+	if len(a.Elements) != len(other.Elements) {
+		return false
+	}
+	for i := range a.Elements {
+		if !a.Elements[i].Equal(&other.Elements[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // Equal compares two FunctionCall

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -282,11 +282,13 @@ type (
 		High AdditionExpression `parser:"@@"`
 	}
 
-	// InExpression handles IN operations with lists, arrays, or subqueries
+	// InExpression handles IN operations with lists, arrays, subqueries, or CTE references
 	InExpression struct {
 		List     []Expression     `parser:"'(' @@ (',' @@)* ')'"`
 		Array    *ArrayExpression `parser:"| @@"`
 		Subquery *Subquery        `parser:"| @@"`
+		// Identifier for CTE references like "IN pending_session_finalization"
+		Ident *string `parser:"| @(Ident | BacktickIdent)"`
 	}
 
 	// IsNullExpr handles IS NULL and IS NOT NULL expressions as postfix operators
@@ -1151,6 +1153,10 @@ func (i InExpression) String() string {
 
 	if i.Subquery != nil {
 		return i.Subquery.String()
+	}
+
+	if i.Ident != nil {
+		return *i.Ident
 	}
 
 	return "()"

--- a/pkg/parser/query.go
+++ b/pkg/parser/query.go
@@ -3,9 +3,34 @@ package parser
 // This file contains comprehensive ClickHouse query parsing structures including SELECT statements
 
 type (
-	// SelectStatement represents a SELECT statement (for subqueries, no semicolon)
+	// SelectStatement represents a SELECT statement that may include UNION/UNION ALL
+	// It contains a primary select and optional union clauses
 	SelectStatement struct {
 		With     *WithClause          `parser:"@@?"`
+		Select   string               `parser:"'SELECT'"`
+		Distinct bool                 `parser:"@'DISTINCT'?"`
+		Columns  []SelectColumn       `parser:"@@ (',' @@)*"`
+		From     *FromClause          `parser:"@@?"`
+		Where    *WhereClause         `parser:"@@?"`
+		GroupBy  *GroupByClause       `parser:"@@?"`
+		Having   *HavingClause        `parser:"@@?"`
+		OrderBy  *SelectOrderByClause `parser:"@@?"`
+		Limit    *LimitClause         `parser:"@@?"`
+		Settings *SettingsClause      `parser:"@@?"`
+		// Union clauses for UNION/UNION ALL/UNION DISTINCT
+		Unions []UnionClause `parser:"@@*"`
+	}
+
+	// UnionClause represents a UNION [ALL|DISTINCT] SELECT clause
+	UnionClause struct {
+		Union    string              `parser:"'UNION'"`
+		All      bool                `parser:"@'ALL'?"`
+		Distinct bool                `parser:"@'DISTINCT'?"`
+		Select   *SimpleSelectClause `parser:"@@"`
+	}
+
+	// SimpleSelectClause represents a SELECT without UNION (used in union chains)
+	SimpleSelectClause struct {
 		Select   string               `parser:"'SELECT'"`
 		Distinct bool                 `parser:"@'DISTINCT'?"`
 		Columns  []SelectColumn       `parser:"@@ (',' @@)*"`

--- a/pkg/parser/table.go
+++ b/pkg/parser/table.go
@@ -218,9 +218,11 @@ type (
 	}
 
 	// TableTTLClause represents table-level TTL expression
+	// Syntax: TTL expression [DELETE [WHERE condition]]
 	TableTTLClause struct {
 		TTL        string     `parser:"'TTL'"`
 		Expression Expression `parser:"@@"`
+		Delete     *TTLDelete `parser:"@@?"`
 	}
 
 	// TableSettingsClause represents SETTINGS clause
@@ -738,7 +740,19 @@ func (t *TableTTLClause) Equal(other *TableTTLClause) bool {
 	if eq, done := compare.NilCheck(t, other); !done {
 		return eq
 	}
-	return t.Expression.Equal(&other.Expression)
+	if !t.Expression.Equal(&other.Expression) {
+		return false
+	}
+	// Compare Delete clause
+	return compare.PointersWithEqual(t.Delete, other.Delete, (*TTLDelete).Equal)
+}
+
+// Equal compares two TTLDelete instances for equality
+func (t *TTLDelete) Equal(other *TTLDelete) bool {
+	if eq, done := compare.NilCheck(t, other); !done {
+		return eq
+	}
+	return compare.PointersWithEqual(t.Where, other.Where, (*Expression).Equal)
 }
 
 // Equal compares two TableEngine instances for equality

--- a/pkg/parser/table_stmt_test.go
+++ b/pkg/parser/table_stmt_test.go
@@ -53,6 +53,15 @@ func TestCreateTable(t *testing.T) {
 		SETTINGS index_granularity = 8192, merge_with_ttl_timeout = 3600
 		COMMENT 'User events table';`},
 
+		// TTL DELETE syntax
+		{name: "ttl_delete", sql: `CREATE TABLE logs (
+			id UInt64,
+			message String,
+			timestamp DateTime
+		) ENGINE = MergeTree()
+		ORDER BY (id, timestamp)
+		TTL timestamp + INTERVAL 30 DAY DELETE;`},
+
 		// Backticks
 		{name: "with_backticks", sql: "CREATE TABLE `user-db`.`order-table` (`user-id` UInt64, `order-id` String, `order-date` Date, `select` String, `group` LowCardinality(String)) ENGINE = MergeTree() ORDER BY (`user-id`, `order-date`);"},
 

--- a/pkg/parser/testdata/table/create/ttl_delete.sql
+++ b/pkg/parser/testdata/table/create/ttl_delete.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `logs` (
+    `id`        UInt64,
+    `message`   String,
+    `timestamp` DateTime
+)
+ENGINE = MergeTree()
+ORDER BY (`id`, `timestamp`)
+TTL `timestamp` + INTERVAL 30 DAY DELETE;

--- a/pkg/parser/testdata/view/create_materialized/refresh_after_hours.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_after_hours.sql
@@ -1,0 +1,4 @@
+CREATE MATERIALIZED VIEW `mv_refresh_after`
+REFRESH AFTER 1 HOUR
+AS SELECT count() AS `cnt`
+FROM `events`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_append_to.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_append_to.sql
@@ -1,0 +1,5 @@
+CREATE MATERIALIZED VIEW `mv_refresh_append`
+REFRESH EVERY 10 SECONDS
+APPEND TO `target_table`
+AS SELECT *
+FROM `source`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_every_minutes.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_every_minutes.sql
@@ -1,0 +1,4 @@
+CREATE MATERIALIZED VIEW `mv_refresh_min`
+REFRESH EVERY 5 MINUTES
+AS SELECT count() AS `cnt`
+FROM `events`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_every_seconds.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_every_seconds.sql
@@ -1,0 +1,4 @@
+CREATE MATERIALIZED VIEW `mv_refresh`
+REFRESH EVERY 10 SECONDS
+AS SELECT count() AS `cnt`
+FROM `events`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_on_cluster.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_on_cluster.sql
@@ -1,0 +1,7 @@
+CREATE MATERIALIZED VIEW `db`.`mv_refresh` ON CLUSTER `mycluster`
+REFRESH EVERY 30 SECONDS
+APPEND TO `db`.`target`
+AS SELECT
+    `id`,
+    `name`
+FROM `source`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_with_cte.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_with_cte.sql
@@ -1,0 +1,16 @@
+CREATE MATERIALIZED VIEW `mv_cte`
+REFRESH EVERY 10 SECONDS
+APPEND TO `target`
+AS WITH
+    `pending` AS (
+        SELECT `id`
+        FROM `lifecycle`
+        GROUP BY `id`
+        HAVING max(`signal`) = 1
+    )
+SELECT
+    `id`,
+    min(`ts`) AS `min_ts`
+FROM `raw`
+WHERE `id` IN pending
+GROUP BY `id`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_with_offset.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_with_offset.sql
@@ -1,0 +1,7 @@
+CREATE MATERIALIZED VIEW `mv_offset`
+REFRESH EVERY 1 DAY OFFSET 6 HOURS
+AS SELECT
+    toDate(`ts`) AS `dt`,
+    count()
+FROM `events`
+GROUP BY `dt`;

--- a/pkg/parser/testdata/view/create_materialized/refresh_with_settings.sql
+++ b/pkg/parser/testdata/view/create_materialized/refresh_with_settings.sql
@@ -1,0 +1,9 @@
+CREATE MATERIALIZED VIEW `mv_refresh_settings`
+REFRESH EVERY 4 MINUTE
+APPEND TO `target_table`
+AS SELECT
+    `domain`,
+    `session_id`
+FROM `events`
+GROUP BY `domain`, `session_id`
+SETTINGS max_bytes_before_external_group_by = 3000000000;

--- a/pkg/parser/testdata/view/create_materialized/with_settings.sql
+++ b/pkg/parser/testdata/view/create_materialized/with_settings.sql
@@ -1,0 +1,8 @@
+CREATE MATERIALIZED VIEW `mv_with_settings`
+AS SELECT
+    `domain`,
+    `session_id`,
+    count() AS `cnt`
+FROM `events`
+GROUP BY `domain`, `session_id`
+SETTINGS max_bytes_before_external_group_by = 3000000000, max_memory_usage = 10000000000;

--- a/pkg/parser/view.go
+++ b/pkg/parser/view.go
@@ -13,11 +13,25 @@ type (
 		Table    *string `parser:"@(Ident | BacktickIdent))"`
 	}
 
+	// RefreshClause represents REFRESH clause for refreshable materialized views.
+	// ClickHouse syntax:
+	//   REFRESH EVERY|AFTER interval [OFFSET interval]
+	RefreshClause struct {
+		Refresh        string  `parser:"'REFRESH'"`
+		Every          bool    `parser:"( @'EVERY'"`
+		After          bool    `parser:"| @'AFTER' )"`
+		Interval       int     `parser:"@Number"`
+		Unit           string  `parser:"@('SECOND' | 'SECONDS' | 'MINUTE' | 'MINUTES' | 'HOUR' | 'HOURS' | 'DAY' | 'DAYS' | 'WEEK' | 'WEEKS' | 'MONTH' | 'MONTHS')"`
+		OffsetInterval *int    `parser:"('OFFSET' @Number"`
+		OffsetUnit     *string `parser:"@('SECOND' | 'SECONDS' | 'MINUTE' | 'MINUTES' | 'HOUR' | 'HOURS' | 'DAY' | 'DAYS' | 'WEEK' | 'WEEKS' | 'MONTH' | 'MONTHS'))?"`
+	}
+
 	// CreateViewStmt represents a CREATE VIEW statement.
 	// Supports both regular views and materialized views.
 	// ClickHouse syntax:
 	//   CREATE [OR REPLACE] [MATERIALIZED] VIEW [IF NOT EXISTS] [db.]view_name [ON CLUSTER cluster]
-	//   [TO [db.]table_name] [ENGINE = engine] [POPULATE]
+	//   [REFRESH EVERY|AFTER interval ...]
+	//   [APPEND] [TO [db.]table_name] [ENGINE = engine] [POPULATE]
 	//   AS SELECT ...
 	CreateViewStmt struct {
 		LeadingCommentField
@@ -29,6 +43,8 @@ type (
 		Database     *string          `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name         string           `parser:"@(Ident | BacktickIdent)"`
 		OnCluster    *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		Refresh      *RefreshClause   `parser:"@@?"`
+		Append       bool             `parser:"@'APPEND'?"`
 		To           *ViewTableTarget `parser:"('TO' @@)?"`
 		Engine       *ViewEngine      `parser:"@@?"`
 		Populate     bool             `parser:"@'POPULATE'?"`

--- a/pkg/parser/view_stmt_test.go
+++ b/pkg/parser/view_stmt_test.go
@@ -28,6 +28,14 @@ func TestCreateMaterializedView(t *testing.T) {
 		{name: "full_options", sql: `CREATE OR REPLACE MATERIALIZED VIEW IF NOT EXISTS analytics.mv_complex ON CLUSTER production TO analytics.destination_table ENGINE = ReplacingMergeTree(version) POPULATE AS SELECT id, name, max(version) AS version, argMax(data, version) AS data FROM source GROUP BY id, name;`},
 		{name: "with_joins", sql: `CREATE MATERIALIZED VIEW analytics.mv_joins ENGINE = MergeTree() ORDER BY (date, category) AS SELECT toDate(e.timestamp) AS date, e.user_id, u.name AS user_name, e.category, count() AS event_count, sum(e.value) AS total_value FROM events AS e LEFT JOIN users AS u ON e.user_id = u.id WHERE e.status = 'completed' GROUP BY date, e.user_id, u.name, e.category;`},
 		{name: "with_states", sql: `CREATE MATERIALIZED VIEW metrics.mv_user_stats_state TO metrics.user_stats_aggregated AS SELECT toDate(timestamp) AS date, user_id, sumState(amount) AS total_amount_state, avgState(duration) AS avg_duration_state, uniqState(session_id) AS unique_sessions_state FROM raw_events GROUP BY date, user_id;`},
+		// Refreshable materialized views
+		{name: "refresh_every_seconds", sql: `CREATE MATERIALIZED VIEW mv_refresh REFRESH EVERY 10 SECONDS AS SELECT count() AS cnt FROM events;`},
+		{name: "refresh_every_minutes", sql: `CREATE MATERIALIZED VIEW mv_refresh_min REFRESH EVERY 5 MINUTES AS SELECT count() AS cnt FROM events;`},
+		{name: "refresh_after_hours", sql: `CREATE MATERIALIZED VIEW mv_refresh_after REFRESH AFTER 1 HOUR AS SELECT count() AS cnt FROM events;`},
+		{name: "refresh_append_to", sql: `CREATE MATERIALIZED VIEW mv_refresh_append REFRESH EVERY 10 SECONDS APPEND TO target_table AS SELECT * FROM source;`},
+		{name: "refresh_on_cluster", sql: `CREATE MATERIALIZED VIEW db.mv_refresh ON CLUSTER mycluster REFRESH EVERY 30 SECONDS APPEND TO db.target AS SELECT id, name FROM source;`},
+		{name: "refresh_with_offset", sql: `CREATE MATERIALIZED VIEW mv_offset REFRESH EVERY 1 DAY OFFSET 6 HOURS AS SELECT toDate(ts) AS dt, count() FROM events GROUP BY dt;`},
+		{name: "refresh_with_cte", sql: `CREATE MATERIALIZED VIEW mv_cte REFRESH EVERY 10 SECONDS APPEND TO target AS WITH pending AS (SELECT id FROM lifecycle GROUP BY id HAVING max(signal) = 1) SELECT id, min(ts) AS min_ts FROM raw WHERE id IN pending GROUP BY id;`},
 	}
 
 	runStatementTests(t, "view/create_materialized", tests)

--- a/pkg/schema/clickhouse_compat_test.go
+++ b/pkg/schema/clickhouse_compat_test.go
@@ -1,0 +1,386 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTTLCompatibility tests TTL clause comparison handling ClickHouse-specific formatting
+func TestTTLCompatibility(t *testing.T) {
+	t.Run("INTERVAL vs toIntervalDay should be equivalent", func(t *testing.T) {
+		// Schema uses INTERVAL syntax
+		schemaSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + INTERVAL 7 DAY;`
+
+		// ClickHouse returns toIntervalDay function
+		clickhouseSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + toIntervalDay(7);`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+
+	t.Run("DELETE keyword is default - no diff expected", func(t *testing.T) {
+		// Schema has explicit DELETE
+		schemaSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + INTERVAL 4 DAY DELETE;`
+
+		// ClickHouse omits DELETE (it's the default)
+		clickhouseSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + toIntervalDay(4);`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+
+	t.Run("different TTL values should be detected", func(t *testing.T) {
+		currentSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + toIntervalDay(7);`
+
+		targetSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + INTERVAL 4 DAY DELETE;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		diffs, err := compareTables(currentParsed, targetParsed)
+		require.NoError(t, err)
+		require.Len(t, diffs, 1, "should detect TTL value change")
+	})
+
+	t.Run("DELETE WHERE clause should be detected", func(t *testing.T) {
+		currentSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + INTERVAL 7 DAY;`
+
+		targetSQL := `CREATE TABLE test.t1 (id Int32, ts DateTime64(3))
+ENGINE = MergeTree ORDER BY id
+TTL toDateTime(ts) + INTERVAL 7 DAY DELETE WHERE id > 100;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		diffs, err := compareTables(currentParsed, targetParsed)
+		require.NoError(t, err)
+		require.Len(t, diffs, 1, "should detect DELETE WHERE addition")
+	})
+}
+
+// TestRefreshIntervalCompatibility tests REFRESH clause comparison
+func TestRefreshIntervalCompatibility(t *testing.T) {
+	t.Run("SECONDS vs SECOND should be equivalent", func(t *testing.T) {
+		schemaSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECONDS APPEND TO test.target
+AS SELECT id FROM test.source;`
+
+		clickhouseSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS SELECT id FROM test.source;`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+}
+
+// TestIntervalInViewQueries tests INTERVAL normalization in view SELECT statements
+func TestIntervalInViewQueries(t *testing.T) {
+	t.Run("INTERVAL in WHERE should match toInterval function", func(t *testing.T) {
+		schemaSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS SELECT id FROM test.source WHERE ts > now() - INTERVAL 1 DAY;`
+
+		clickhouseSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS SELECT id FROM test.source WHERE ts > now() - toIntervalDay(1);`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+
+	t.Run("extra parentheses in expressions should be equivalent", func(t *testing.T) {
+		schemaSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS SELECT id FROM test.source WHERE ts > now() - INTERVAL 1 DAY;`
+
+		// ClickHouse adds parentheses around arithmetic
+		clickhouseSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS SELECT id FROM test.source WHERE ts > (now() - toIntervalDay(1));`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+}
+
+// TestCTECompatibility tests CTE (WITH clause) comparison
+func TestCTECompatibility(t *testing.T) {
+	t.Run("IN cte vs IN (cte) should be equivalent", func(t *testing.T) {
+		schemaSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS WITH cte AS (SELECT id FROM t1)
+SELECT * FROM t2 WHERE id IN cte;`
+
+		clickhouseSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS WITH cte AS (SELECT id FROM t1)
+SELECT * FROM t2 WHERE id IN (cte);`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+
+	t.Run("CTE WHERE clause change should be detected", func(t *testing.T) {
+		currentSQL := `CREATE MATERIALIZED VIEW test.mv AS
+WITH cte AS (SELECT id FROM t1)
+SELECT * FROM cte;`
+
+		targetSQL := `CREATE MATERIALIZED VIEW test.mv AS
+WITH cte AS (SELECT id FROM t1 WHERE x > 1)
+SELECT * FROM cte;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.False(t, viewsAreEqual(views1["test.mv"], views2["test.mv"]))
+	})
+
+	t.Run("CTE HAVING clause change should be detected", func(t *testing.T) {
+		currentSQL := `CREATE MATERIALIZED VIEW test.mv AS
+WITH cte AS (SELECT id FROM t1 GROUP BY id)
+SELECT * FROM cte;`
+
+		targetSQL := `CREATE MATERIALIZED VIEW test.mv AS
+WITH cte AS (SELECT id FROM t1 GROUP BY id HAVING count(*) > 1)
+SELECT * FROM cte;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.False(t, viewsAreEqual(views1["test.mv"], views2["test.mv"]))
+	})
+}
+
+// TestSettingsCompatibility tests SETTINGS clause comparison
+func TestSettingsCompatibility(t *testing.T) {
+	t.Run("extra index_granularity setting should be ignored", func(t *testing.T) {
+		schemaSQL := `CREATE TABLE test.t1 (id Int32)
+ENGINE = MergeTree ORDER BY id
+SETTINGS storage_policy = 'tiered';`
+
+		// ClickHouse adds default index_granularity
+		clickhouseSQL := `CREATE TABLE test.t1 (id Int32)
+ENGINE = MergeTree ORDER BY id
+SETTINGS storage_policy = 'tiered', index_granularity = 8192;`
+
+		schemaParsed, err := parser.ParseString(schemaSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, schemaParsed)
+		require.ErrorIs(t, err, ErrNoDiff)
+		require.Nil(t, diff)
+	})
+
+	t.Run("view SETTINGS change should be detected", func(t *testing.T) {
+		currentSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 1 MINUTE APPEND TO test.target
+AS SELECT id FROM test.source;`
+
+		targetSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 1 MINUTE APPEND TO test.target
+AS SELECT id FROM test.source
+SETTINGS max_memory_usage = 3000000000;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.False(t, viewsAreEqual(views1["test.mv"], views2["test.mv"]))
+	})
+}
+
+// TestViewQueryChanges tests that meaningful query changes are detected
+func TestViewQueryChanges(t *testing.T) {
+	t.Run("LIMIT change should be detected", func(t *testing.T) {
+		currentSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 1 MINUTE APPEND TO test.target
+AS SELECT id FROM test.source LIMIT 100000;`
+
+		targetSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 1 MINUTE APPEND TO test.target
+AS SELECT id FROM test.source LIMIT 500000;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.False(t, viewsAreEqual(views1["test.mv"], views2["test.mv"]))
+	})
+
+	t.Run("UNION ALL addition should be detected", func(t *testing.T) {
+		currentSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 1 MINUTE APPEND TO test.target
+AS SELECT id FROM test.source;`
+
+		targetSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 1 MINUTE APPEND TO test.target
+AS SELECT id FROM (
+    SELECT id FROM test.source1
+    UNION ALL
+    SELECT id FROM test.source2
+);`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.False(t, viewsAreEqual(views1["test.mv"], views2["test.mv"]))
+	})
+}
+
+// TestTableRoundTrip tests that a table is stable after migration
+func TestTableRoundTrip(t *testing.T) {
+	t.Run("table should be stable after migration", func(t *testing.T) {
+		// What migration generates
+		migrationSQL := `CREATE TABLE test.t1 (
+    id UUID,
+    name String,
+    ts DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC')
+)
+ENGINE = MergeTree
+PARTITION BY toStartOfDay(ts)
+ORDER BY id
+TTL toDateTime(ts) + INTERVAL 4 DAY DELETE
+SETTINGS storage_policy = 'tiered';`
+
+		// What ClickHouse returns
+		clickhouseSQL := `CREATE TABLE test.t1 (
+    id UUID,
+    name String,
+    ts DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC')
+)
+ENGINE = MergeTree
+PARTITION BY toStartOfDay(ts)
+ORDER BY id
+TTL toDateTime(ts) + toIntervalDay(4)
+SETTINGS storage_policy = 'tiered', index_granularity = 8192;`
+
+		migrationParsed, err := parser.ParseString(migrationSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, migrationParsed)
+		require.ErrorIs(t, err, ErrNoDiff, "table should be stable after migration")
+		require.Nil(t, diff)
+	})
+}
+
+// TestViewRoundTrip tests that a view is stable after migration
+func TestViewRoundTrip(t *testing.T) {
+	t.Run("view with CTE should be stable after migration", func(t *testing.T) {
+		// What migration generates
+		migrationSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECONDS APPEND TO test.target
+AS WITH cte AS (
+    SELECT id FROM test.source
+    WHERE ts > now() - INTERVAL 1 DAY
+    GROUP BY id
+    HAVING count(*) > 1
+    LIMIT 100000
+)
+SELECT id FROM test.data WHERE id IN cte;`
+
+		// What ClickHouse returns
+		clickhouseSQL := `CREATE MATERIALIZED VIEW test.mv
+REFRESH EVERY 10 SECOND APPEND TO test.target
+AS WITH cte AS (
+    SELECT id FROM test.source
+    WHERE ts > (now() - toIntervalDay(1))
+    GROUP BY id
+    HAVING count(*) > 1
+    LIMIT 100000
+)
+SELECT id FROM test.data WHERE id IN (cte);`
+
+		migrationParsed, err := parser.ParseString(migrationSQL)
+		require.NoError(t, err)
+		clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+		require.NoError(t, err)
+
+		diff, err := GenerateDiff(clickhouseParsed, migrationParsed)
+		require.ErrorIs(t, err, ErrNoDiff, "view should be stable after migration")
+		require.Nil(t, diff)
+	})
+}

--- a/pkg/schema/clickhouse_compat_test.go
+++ b/pkg/schema/clickhouse_compat_test.go
@@ -1,8 +1,10 @@
 package schema
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/pseudomuto/housekeeper/pkg/format"
 	"github.com/pseudomuto/housekeeper/pkg/parser"
 	"github.com/stretchr/testify/require"
 )
@@ -307,6 +309,124 @@ AS SELECT id FROM (
 
 		require.False(t, viewsAreEqual(views1["test.mv"], views2["test.mv"]))
 	})
+
+	t.Run("raw_sessions_mv_ws_path_any_vs_nullIf_should_be_detected", func(t *testing.T) {
+		// Old: any(ws_path) - empty string stored as-is
+		currentSQL := `CREATE MATERIALIZED VIEW perceptor.raw_sessions_mv ON CLUSTER explorations
+TO perceptor.raw_sessions_local
+AS SELECT domain, session_id, any(ws_path) AS ws_path FROM perceptor.raw_events_local GROUP BY domain, session_id;`
+
+		// New: any(nullIf(ws_path,'')) - empty string normalized to NULL
+		targetSQL := `CREATE MATERIALIZED VIEW perceptor.raw_sessions_mv ON CLUSTER explorations
+TO perceptor.raw_sessions_local
+AS SELECT domain, session_id, any(nullIf(ws_path, '')) AS ws_path FROM perceptor.raw_events_local GROUP BY domain, session_id;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.Contains(t, views1, "perceptor.raw_sessions_mv")
+		require.Contains(t, views2, "perceptor.raw_sessions_mv")
+		require.False(t, viewsAreEqual(views1["perceptor.raw_sessions_mv"], views2["perceptor.raw_sessions_mv"]),
+			"change from any(ws_path) to any(nullIf(ws_path,'')) should be detected")
+	})
+
+	t.Run("session_lifecycle_timeout_signal_mv_where_predicates_should_be_detected", func(t *testing.T) {
+		// Old: no time bounds in CTE or main WHERE
+		currentSQL := `CREATE MATERIALIZED VIEW perceptor.session_lifecycle_timeout_signal_mv ON CLUSTER explorations
+REFRESH EVERY 60 SECOND APPEND TO perceptor.session_lifecycle_local
+AS WITH already_ended AS (
+    SELECT DISTINCT domain, session_id FROM perceptor.session_lifecycle_local WHERE signal = 'session_end'
+)
+SELECT domain, session_id, 'session_end' AS signal, now64(3, 'UTC') AS received_at
+FROM perceptor.raw_sessions_local
+WHERE max_event_received_at < now64(3, 'UTC') - INTERVAL 3 HOUR AND (domain, session_id) NOT IN already_ended
+LIMIT 100000;`
+
+		// New: add AND max_event_received_at > now64(...) - INTERVAL 36 HOUR and AND received_at > now() - INTERVAL 2 DAY
+		targetSQL := `CREATE MATERIALIZED VIEW perceptor.session_lifecycle_timeout_signal_mv ON CLUSTER explorations
+REFRESH EVERY 60 SECOND APPEND TO perceptor.session_lifecycle_local
+AS WITH already_ended AS (
+    SELECT DISTINCT domain, session_id FROM perceptor.session_lifecycle_local
+    WHERE signal = 'session_end' AND received_at > now() - INTERVAL 2 DAY
+)
+SELECT domain, session_id, 'session_end' AS signal, now64(3, 'UTC') AS received_at
+FROM perceptor.raw_sessions_local
+WHERE max_event_received_at < now64(3, 'UTC') - INTERVAL 3 HOUR AND max_event_received_at > now64(3, 'UTC') - INTERVAL 36 HOUR AND (domain, session_id) NOT IN already_ended
+LIMIT 100000;`
+
+		currentParsed, err := parser.ParseString(currentSQL)
+		require.NoError(t, err)
+		targetParsed, err := parser.ParseString(targetSQL)
+		require.NoError(t, err)
+
+		views1 := extractViewsFromSQL(currentParsed)
+		views2 := extractViewsFromSQL(targetParsed)
+
+		require.Contains(t, views1, "perceptor.session_lifecycle_timeout_signal_mv")
+		require.Contains(t, views2, "perceptor.session_lifecycle_timeout_signal_mv")
+		require.False(t, viewsAreEqual(views1["perceptor.session_lifecycle_timeout_signal_mv"], views2["perceptor.session_lifecycle_timeout_signal_mv"]),
+			"addition of WHERE predicates (max_event_received_at > 36h, received_at > 2d) should be detected")
+	})
+}
+
+// TestGenerateDiff_DetectsMVChanges_Integration tests that GenerateDiff produces view ALTERs
+// when current (DB) has old MV definitions and target (schema files) has the updated definitions:
+// raw_sessions_mv ws_path: any(ws_path) -> any(nullIf(ws_path,”)); session_lifecycle_timeout_signal_mv:
+// two added WHERE predicates (max_event_received_at > 36h, received_at > 2d).
+func TestGenerateDiff_DetectsMVChanges_Integration(t *testing.T) {
+	// Current = state after applying existing migrations (old MV definitions)
+	currentSQL := `CREATE MATERIALIZED VIEW perceptor.raw_sessions_mv ON CLUSTER explorations
+TO perceptor.raw_sessions_local
+AS SELECT domain, session_id, any(ws_path) AS ws_path FROM perceptor.raw_events_local GROUP BY domain, session_id;
+
+CREATE MATERIALIZED VIEW perceptor.session_lifecycle_timeout_signal_mv ON CLUSTER explorations
+REFRESH EVERY 60 SECOND APPEND TO perceptor.session_lifecycle_local
+AS WITH already_ended AS (
+    SELECT DISTINCT domain, session_id FROM perceptor.session_lifecycle_local WHERE signal = 'session_end'
+)
+SELECT domain, session_id, 'session_end' AS signal, now64(3, 'UTC') AS received_at
+FROM perceptor.raw_sessions_local
+WHERE max_event_received_at < now64(3, 'UTC') - INTERVAL 3 HOUR AND (domain, session_id) NOT IN already_ended
+LIMIT 100000;`
+
+	// Target = compiled schema with user edits (new MV definitions)
+	targetSQL := `CREATE MATERIALIZED VIEW perceptor.raw_sessions_mv ON CLUSTER explorations
+TO perceptor.raw_sessions_local
+AS SELECT domain, session_id, any(nullIf(ws_path, '')) AS ws_path FROM perceptor.raw_events_local GROUP BY domain, session_id;
+
+CREATE MATERIALIZED VIEW perceptor.session_lifecycle_timeout_signal_mv ON CLUSTER explorations
+REFRESH EVERY 60 SECOND APPEND TO perceptor.session_lifecycle_local
+AS WITH already_ended AS (
+    SELECT DISTINCT domain, session_id FROM perceptor.session_lifecycle_local
+    WHERE signal = 'session_end' AND received_at > now() - INTERVAL 2 DAY
+)
+SELECT domain, session_id, 'session_end' AS signal, now64(3, 'UTC') AS received_at
+FROM perceptor.raw_sessions_local
+WHERE max_event_received_at < now64(3, 'UTC') - INTERVAL 3 HOUR AND max_event_received_at > now64(3, 'UTC') - INTERVAL 36 HOUR AND (domain, session_id) NOT IN already_ended
+LIMIT 100000;`
+
+	currentParsed, err := parser.ParseString(currentSQL)
+	require.NoError(t, err)
+	targetParsed, err := parser.ParseString(targetSQL)
+	require.NoError(t, err)
+
+	diff, err := GenerateDiff(currentParsed, targetParsed)
+	require.NoError(t, err, "GenerateDiff should succeed and produce a diff")
+	require.NotNil(t, diff, "diff should not be nil")
+	require.False(t, len(diff.Statements) == 0, "diff should contain statements")
+
+	var buf bytes.Buffer
+	err = format.FormatSQL(&buf, format.Defaults, diff)
+	require.NoError(t, err)
+	diffStr := buf.String()
+
+	require.Contains(t, diffStr, "raw_sessions_mv", "diff should include raw_sessions_mv (DROP/CREATE)")
+	require.Contains(t, diffStr, "session_lifecycle_timeout_signal_mv", "diff should include session_lifecycle_timeout_signal_mv (DROP/CREATE)")
 }
 
 // TestTableRoundTrip tests that a table is stable after migration
@@ -383,4 +503,89 @@ SELECT id FROM test.data WHERE id IN (cte);`
 		require.ErrorIs(t, err, ErrNoDiff, "view should be stable after migration")
 		require.Nil(t, diff)
 	})
+}
+
+// TestIN_cte_vs_IN_cte_WHERE_equal ensures WHERE (a,b) IN (cte) (dump) compares equal to WHERE (a,b) IN cte (schema).
+// So finalize_sessions_mv-style views are not incorrectly flagged for alter.
+func TestIN_cte_vs_IN_cte_WHERE_equal(t *testing.T) {
+	// Schema: IN cte (no parens around CTE name)
+	schemaSQL := `CREATE MATERIALIZED VIEW test.mv TO test.target
+AS WITH cte AS (SELECT domain, session_id FROM test.t)
+SELECT domain, session_id FROM test.source WHERE (domain, session_id) IN cte;`
+
+	// Dump: IN (cte) (ClickHouse wraps CTE ref in parens)
+	dumpSQL := `CREATE MATERIALIZED VIEW test.mv TO test.target
+AS WITH cte AS (SELECT domain, session_id FROM test.t)
+SELECT domain, session_id FROM test.source WHERE (domain, session_id) IN (cte);`
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err)
+	dumpParsed, err := parser.ParseString(dumpSQL)
+	require.NoError(t, err)
+
+	viewsSchema := extractViewsFromSQL(schemaParsed)
+	viewsDump := extractViewsFromSQL(dumpParsed)
+	require.Len(t, viewsSchema, 1)
+	require.Len(t, viewsDump, 1)
+
+	equal := viewsAreEqual(viewsDump["test.mv"], viewsSchema["test.mv"])
+	require.True(t, equal, "IN (cte) (dump) should compare equal to IN cte (schema)")
+}
+
+// TestNoDiffWhenOnlyFormattingDiffers ensures GenerateDiff returns no view diff when current and target
+// only differ by formatting (backticks, IN (cte) vs IN cte). So re-running diff does not regenerate.
+func TestNoDiffWhenOnlyFormattingDiffers(t *testing.T) {
+	// Schema (no backticks, IN cte)
+	schemaSQL := `CREATE MATERIALIZED VIEW test.finalize_mv ON CLUSTER explorations
+REFRESH EVERY 4 MINUTE APPEND TO test.finalized_local
+AS WITH pending AS (SELECT domain, session_id FROM test.lifecycle WHERE received_at > now() - INTERVAL 6 HOUR GROUP BY domain, session_id HAVING max(signal) = 1 LIMIT 350000)
+SELECT r.domain, r.session_id, max(r.ws_path) AS ws_path FROM test.raw_local AS r WHERE (r.domain, r.session_id) IN pending GROUP BY r.domain, r.session_id;`
+
+	// Dump (backticks, IN (pending))
+	dumpSQL := "CREATE MATERIALIZED VIEW test.finalize_mv ON CLUSTER explorations\n" +
+		"REFRESH EVERY 4 MINUTE APPEND TO test.finalized_local\n" +
+		"AS WITH pending AS (SELECT domain, session_id FROM test.lifecycle WHERE received_at > now() - INTERVAL 6 HOUR GROUP BY domain, session_id HAVING max(signal) = 1 LIMIT 350000)\n" +
+		"SELECT `r`.`domain`, `r`.`session_id`, max(`r`.`ws_path`) AS `ws_path` FROM test.raw_local AS r WHERE (r.domain, r.session_id) IN (pending) GROUP BY r.domain, r.session_id;"
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err)
+	dumpParsed, err := parser.ParseString(dumpSQL)
+	require.NoError(t, err)
+
+	_, err = GenerateDiff(dumpParsed, schemaParsed)
+	require.ErrorIs(t, err, ErrNoDiff, "dump (backticks, IN (cte)) should match schema so diff:force does not regenerate")
+}
+
+// TestAlterOnlyForChangedViews ensures only views that actually changed get alter diffs;
+// unchanged views (e.g. finalize_sessions_mv) must not be dropped/recreated.
+func TestAlterOnlyForChangedViews(t *testing.T) {
+	// Current: 3 MVs. finalize_mv unchanged; raw_mv old ws_path; timeout_mv without extra WHERE predicates.
+	currentSQL := `CREATE MATERIALIZED VIEW test.finalize_mv TO test.finalized AS WITH cte AS (SELECT id FROM t) SELECT id, max(ws_path) AS ws_path FROM test.raw GROUP BY id;
+CREATE MATERIALIZED VIEW test.raw_mv TO test.raw_local AS SELECT domain, session_id, any(ws_path) AS ws_path FROM test.events GROUP BY domain, session_id;
+CREATE MATERIALIZED VIEW test.timeout_mv TO test.lifecycle AS SELECT domain, session_id FROM test.raw WHERE ts < now() - INTERVAL 3 HOUR LIMIT 1000;`
+
+	// Target: same 3 MVs. finalize_mv still unchanged; raw_mv new ws_path; timeout_mv with extra WHERE.
+	targetSQL := `CREATE MATERIALIZED VIEW test.finalize_mv TO test.finalized AS WITH cte AS (SELECT id FROM t) SELECT id, max(ws_path) AS ws_path FROM test.raw GROUP BY id;
+CREATE MATERIALIZED VIEW test.raw_mv TO test.raw_local AS SELECT domain, session_id, any(nullIf(ws_path, '')) AS ws_path FROM test.events GROUP BY domain, session_id;
+CREATE MATERIALIZED VIEW test.timeout_mv TO test.lifecycle AS SELECT domain, session_id FROM test.raw WHERE ts < now() - INTERVAL 3 HOUR AND ts > now() - INTERVAL 36 HOUR LIMIT 1000;`
+
+	currentParsed, err := parser.ParseString(currentSQL)
+	require.NoError(t, err)
+	targetParsed, err := parser.ParseString(targetSQL)
+	require.NoError(t, err)
+
+	diff, err := GenerateDiff(currentParsed, targetParsed)
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	var buf bytes.Buffer
+	err = format.FormatSQL(&buf, format.Defaults, diff)
+	require.NoError(t, err)
+	diffStr := buf.String()
+
+	// Should alter raw_mv and timeout_mv only
+	require.Contains(t, diffStr, "raw_mv", "diff should include raw_mv (changed)")
+	require.Contains(t, diffStr, "timeout_mv", "diff should include timeout_mv (changed)")
+	// finalize_mv must NOT be in the diff (unchanged)
+	require.NotContains(t, diffStr, "finalize_mv", "diff must not drop/recreate finalize_mv (unchanged)")
 }

--- a/pkg/schema/nested.go
+++ b/pkg/schema/nested.go
@@ -194,3 +194,31 @@ func copyBoolMap(m map[string]bool) map[string]bool {
 	maps.Copy(copy, m)
 	return copy
 }
+
+// HasNestedColumns returns true if the table has any columns with the Nested data type.
+// This is used to detect if ClickHouse has flatten_nested=0 (Nested columns are kept as-is).
+func HasNestedColumns(table *TableInfo) bool {
+	if table == nil {
+		return false
+	}
+	for _, col := range table.Columns {
+		if col.DataType != nil && col.DataType.Nested != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// MaybeFlattendNestedColumns conditionally flattens Nested columns based on whether
+// the current schema from ClickHouse has Nested columns (flatten_nested=0) or not.
+// If current table has Nested columns, target is returned as-is (no flattening).
+// If current table has flattened columns, target is flattened to match.
+func MaybeFlattenNestedColumns(currentTable, targetTable *TableInfo) *TableInfo {
+	// If current table has Nested columns, ClickHouse has flatten_nested=0
+	// Don't flatten the target - compare Nested to Nested
+	if HasNestedColumns(currentTable) {
+		return targetTable
+	}
+	// Current table has flattened columns, flatten target to match
+	return FlattenNestedColumns(targetTable)
+}

--- a/pkg/schema/nested_test.go
+++ b/pkg/schema/nested_test.go
@@ -339,6 +339,324 @@ func TestDetectNestedGroups(t *testing.T) {
 	}
 }
 
+func TestHasNestedColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		table    *schema.TableInfo
+		expected bool
+	}{
+		{
+			name:     "nil table",
+			table:    nil,
+			expected: false,
+		},
+		{
+			name: "table with no columns",
+			table: &schema.TableInfo{
+				Name:    "empty",
+				Columns: []schema.ColumnInfo{},
+			},
+			expected: false,
+		},
+		{
+			name: "table with only simple columns",
+			table: &schema.TableInfo{
+				Name: "users",
+				Columns: []schema.ColumnInfo{
+					{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+					{Name: "name", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "table with flattened columns (dotted arrays)",
+			table: &schema.TableInfo{
+				Name: "users",
+				Columns: []schema.ColumnInfo{
+					{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+					{Name: "profile.name", DataType: &parser.DataType{Array: &parser.ArrayType{Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}}}},
+					{Name: "profile.age", DataType: &parser.DataType{Array: &parser.ArrayType{Type: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt8"}}}}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "table with nested column",
+			table: &schema.TableInfo{
+				Name: "users",
+				Columns: []schema.ColumnInfo{
+					{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+					{
+						Name: "profile",
+						DataType: &parser.DataType{
+							Nested: &parser.NestedType{
+								Nested: "Nested",
+								Columns: []parser.NestedColumn{
+									{Name: "name", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+									{Name: "age", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt8"}}},
+								},
+								Close: ")",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "table with mixed columns including nested",
+			table: &schema.TableInfo{
+				Name: "events",
+				Columns: []schema.ColumnInfo{
+					{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+					{Name: "name", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+					{Name: "tags", DataType: &parser.DataType{Array: &parser.ArrayType{Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}}}},
+					{
+						Name: "metadata",
+						DataType: &parser.DataType{
+							Nested: &parser.NestedType{
+								Nested: "Nested",
+								Columns: []parser.NestedColumn{
+									{Name: "key", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+									{Name: "value", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+								},
+								Close: ")",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := schema.HasNestedColumns(tt.table)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMaybeFlattenNestedColumns(t *testing.T) {
+	// Helper to create a simple table
+	simpleTable := func(name string) *schema.TableInfo {
+		return &schema.TableInfo{
+			Name: name,
+			Columns: []schema.ColumnInfo{
+				{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+			},
+		}
+	}
+
+	// Helper to create a table with Nested column
+	nestedTable := func(name string) *schema.TableInfo {
+		return &schema.TableInfo{
+			Name: name,
+			Columns: []schema.ColumnInfo{
+				{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+				{
+					Name: "profile",
+					DataType: &parser.DataType{
+						Nested: &parser.NestedType{
+							Nested: "Nested",
+							Columns: []parser.NestedColumn{
+								{Name: "name", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+								{Name: "age", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt8"}}},
+							},
+							Close: ")",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Helper to create a table with flattened columns (what ClickHouse returns with flatten_nested=1)
+	flattenedTable := func(name string) *schema.TableInfo {
+		return &schema.TableInfo{
+			Name: name,
+			Columns: []schema.ColumnInfo{
+				{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+				{Name: "profile.name", DataType: &parser.DataType{Array: &parser.ArrayType{Array: "Array", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}, Close: ")"}}},
+				{Name: "profile.age", DataType: &parser.DataType{Array: &parser.ArrayType{Array: "Array", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt8"}}, Close: ")"}}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		currentTable    *schema.TableInfo
+		targetTable     *schema.TableInfo
+		expectFlattened bool // true if result should have flattened columns
+	}{
+		{
+			name:            "current has Nested - don't flatten target",
+			currentTable:    nestedTable("current"),
+			targetTable:     nestedTable("target"),
+			expectFlattened: false,
+		},
+		{
+			name:            "current has flattened - flatten target",
+			currentTable:    flattenedTable("current"),
+			targetTable:     nestedTable("target"),
+			expectFlattened: true,
+		},
+		{
+			name:            "current is simple - flatten target with nested",
+			currentTable:    simpleTable("current"),
+			targetTable:     nestedTable("target"),
+			expectFlattened: true,
+		},
+		{
+			name:            "both simple tables - no change needed",
+			currentTable:    simpleTable("current"),
+			targetTable:     simpleTable("target"),
+			expectFlattened: false, // No nested columns to flatten
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := schema.MaybeFlattenNestedColumns(tt.currentTable, tt.targetTable)
+
+			require.NotNil(t, result)
+
+			// Check if result has flattened columns (dotted names with Array type)
+			hasFlattened := false
+			hasNested := false
+			for _, col := range result.Columns {
+				if col.DataType != nil && col.DataType.Nested != nil {
+					hasNested = true
+				}
+				// Check for dotted column names which indicate flattening
+				for _, c := range col.Name {
+					if c == '.' {
+						hasFlattened = true
+						break
+					}
+				}
+			}
+
+			if tt.expectFlattened {
+				// Should have flattened columns (dotted names) and no Nested
+				require.True(t, hasFlattened || !schema.HasNestedColumns(tt.targetTable),
+					"expected flattened columns")
+				require.False(t, hasNested, "should not have Nested columns after flattening")
+			} else {
+				// Should preserve original structure
+				if schema.HasNestedColumns(tt.targetTable) {
+					require.True(t, hasNested, "should preserve Nested columns")
+				}
+			}
+		})
+	}
+}
+
+func TestMaybeFlattenNestedColumns_PreservesIdentityWhenCurrentHasNested(t *testing.T) {
+	// When current table has Nested columns (flatten_nested=0),
+	// the target should be returned as-is without flattening
+
+	targetTable := &schema.TableInfo{
+		Name: "target",
+		Columns: []schema.ColumnInfo{
+			{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+			{
+				Name: "visual_matches",
+				DataType: &parser.DataType{
+					Nested: &parser.NestedType{
+						Nested: "Nested",
+						Columns: []parser.NestedColumn{
+							{Name: "start", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}},
+							{Name: "end", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}},
+							{Name: "word", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+							{Name: "snippet", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+						},
+						Close: ")",
+					},
+				},
+			},
+		},
+	}
+
+	currentTable := &schema.TableInfo{
+		Name: "current",
+		Columns: []schema.ColumnInfo{
+			{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+			{
+				Name: "visual_matches",
+				DataType: &parser.DataType{
+					Nested: &parser.NestedType{
+						Nested: "Nested",
+						Columns: []parser.NestedColumn{
+							{Name: "start", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}},
+							{Name: "end", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}},
+							{Name: "word", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+							{Name: "snippet", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "String"}}},
+						},
+						Close: ")",
+					},
+				},
+			},
+		},
+	}
+
+	result := schema.MaybeFlattenNestedColumns(currentTable, targetTable)
+
+	// Result should be the same as targetTable (not flattened)
+	require.Equal(t, targetTable, result, "should return target as-is when current has Nested columns")
+	require.Len(t, result.Columns, 2, "should have 2 columns (not flattened to 5)")
+	require.Equal(t, "visual_matches", result.Columns[1].Name, "should keep Nested column name")
+	require.NotNil(t, result.Columns[1].DataType.Nested, "should keep Nested type")
+}
+
+func TestMaybeFlattenNestedColumns_FlattensWhenCurrentHasFlattened(t *testing.T) {
+	// When current table has flattened columns (flatten_nested=1 default),
+	// the target should be flattened to match
+
+	targetTable := &schema.TableInfo{
+		Name: "target",
+		Columns: []schema.ColumnInfo{
+			{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+			{
+				Name: "visual_matches",
+				DataType: &parser.DataType{
+					Nested: &parser.NestedType{
+						Nested: "Nested",
+						Columns: []parser.NestedColumn{
+							{Name: "start", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}},
+							{Name: "end", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}},
+						},
+						Close: ")",
+					},
+				},
+			},
+		},
+	}
+
+	// Current table as returned by ClickHouse with flatten_nested=1
+	currentTable := &schema.TableInfo{
+		Name: "current",
+		Columns: []schema.ColumnInfo{
+			{Name: "id", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}},
+			{Name: "visual_matches.start", DataType: &parser.DataType{Array: &parser.ArrayType{Array: "Array", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}, Close: ")"}}},
+			{Name: "visual_matches.end", DataType: &parser.DataType{Array: &parser.ArrayType{Array: "Array", Type: &parser.DataType{Simple: &parser.SimpleType{Name: "Int32"}}, Close: ")"}}},
+		},
+	}
+
+	result := schema.MaybeFlattenNestedColumns(currentTable, targetTable)
+
+	// Result should be flattened
+	require.NotEqual(t, targetTable, result, "should return flattened copy")
+	require.Len(t, result.Columns, 3, "should have 3 columns (flattened from 2)")
+	require.Equal(t, "id", result.Columns[0].Name)
+	require.Equal(t, "visual_matches.start", result.Columns[1].Name)
+	require.Equal(t, "visual_matches.end", result.Columns[2].Name)
+	require.NotNil(t, result.Columns[1].DataType.Array, "should be Array type")
+	require.NotNil(t, result.Columns[2].DataType.Array, "should be Array type")
+}
+
 // Helper function to format data types for comparison
 func formatDataType(dt *parser.DataType) string {
 	if dt == nil {

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -372,10 +372,11 @@ func propagateColumnChangesToDependents(
 		// Generate SQL based on engine type
 		if isViewLikeEngine(targetDep.Engine) {
 			// For Distributed, Memory, etc.: DROP + CREATE is safe and necessary
+			// Note: generateDropTableSQL already includes semicolon from SQLBuilder
 			propDiff.UpSQL = fmt.Sprintf("-- Recreate to match schema changes from %s\n", sourceDiff.Name) +
-				generateDropTableSQL(currentDep) + ";\n" +
+				generateDropTableSQL(currentDep) + "\n" +
 				generateCreateTableSQL(targetDep)
-			propDiff.DownSQL = generateDropTableSQL(targetDep) + ";\n" +
+			propDiff.DownSQL = generateDropTableSQL(targetDep) + "\n" +
 				generateCreateTableSQL(currentDep)
 		} else {
 			// For MergeTree, etc.: Use ALTER to preserve data

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/pseudomuto/housekeeper/pkg/compare"
@@ -91,6 +92,8 @@ const (
 	ColumnDiffDrop ColumnDiffType = "DROP"
 	// ColumnDiffModify indicates a column needs to be modified
 	ColumnDiffModify ColumnDiffType = "MODIFY"
+	// ColumnDiffRename indicates a column needs to be renamed
+	ColumnDiffRename ColumnDiffType = "RENAME"
 )
 
 // GetName implements SchemaObject interface.
@@ -743,12 +746,17 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 	// Create maps for easier lookup
 	currentCols := make(map[string]ColumnInfo)
 	targetCols := make(map[string]ColumnInfo)
+	// Also create position maps for rename detection
+	currentPositions := make(map[string]int)
+	targetPositions := make(map[string]int)
 
-	for _, col := range current {
+	for i, col := range current {
 		currentCols[col.Name] = col
+		currentPositions[col.Name] = i
 	}
-	for _, col := range target {
+	for i, col := range target {
 		targetCols[col.Name] = col
+		targetPositions[col.Name] = i
 	}
 
 	// Find columns to add or modify
@@ -756,16 +764,37 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 		if currentCol, exists := currentCols[targetCol.Name]; exists {
 			// Column exists - check for changes using Equal() method
 			if !currentCol.Equal(targetCol) {
-				// Fix: Create copies to avoid loop variable pointer issues
-				currentColCopy := currentCol
-				targetColCopy := targetCol
-				diffs = append(diffs, ColumnDiff{
-					Type:        ColumnDiffModify,
-					ColumnName:  targetCol.Name,
-					Current:     &currentColCopy,
-					Target:      &targetColCopy,
-					Description: "Modify column " + targetCol.Name,
-				})
+				// Check if this is an incompatible AggregateFunction type change
+				// ClickHouse doesn't support MODIFY for AggregateFunction type changes
+				// We need to use DROP + ADD instead
+				if isIncompatibleAggregateFunctionChange(currentCol.DataType, targetCol.DataType) {
+					// Convert to DROP + ADD instead of MODIFY
+					currentColCopy := currentCol
+					targetColCopy := targetCol
+					diffs = append(diffs, ColumnDiff{
+						Type:        ColumnDiffDrop,
+						ColumnName:  currentCol.Name,
+						Current:     &currentColCopy,
+						Description: "Drop column " + currentCol.Name + " (incompatible AggregateFunction change)",
+					})
+					diffs = append(diffs, ColumnDiff{
+						Type:        ColumnDiffAdd,
+						ColumnName:  targetCol.Name,
+						Target:      &targetColCopy,
+						Description: "Add column " + targetCol.Name + " (replacing incompatible AggregateFunction)",
+					})
+				} else {
+					// Fix: Create copies to avoid loop variable pointer issues
+					currentColCopy := currentCol
+					targetColCopy := targetCol
+					diffs = append(diffs, ColumnDiff{
+						Type:        ColumnDiffModify,
+						ColumnName:  targetCol.Name,
+						Current:     &currentColCopy,
+						Target:      &targetColCopy,
+						Description: "Modify column " + targetCol.Name,
+					})
+				}
 			}
 		} else {
 			// Column needs to be added
@@ -794,7 +823,315 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 		}
 	}
 
+	// Detect renames: match DROP and ADD columns with matching types
+	// Use position as primary match, but use name similarity as tiebreaker
+	type posDiff struct {
+		diff *ColumnDiff
+		idx  int
+		pos  int
+	}
+	dropDiffs := make([]posDiff, 0)
+	addDiffs := make([]posDiff, 0)
+
+	// Collect DROP and ADD diffs with their positions
+	for i := range diffs {
+		diff := &diffs[i]
+		if diff.Type == ColumnDiffDrop {
+			if pos, exists := currentPositions[diff.ColumnName]; exists {
+				dropDiffs = append(dropDiffs, posDiff{diff: diff, idx: i, pos: pos})
+			}
+		} else if diff.Type == ColumnDiffAdd {
+			if pos, exists := targetPositions[diff.ColumnName]; exists {
+				addDiffs = append(addDiffs, posDiff{diff: diff, idx: i, pos: pos})
+			}
+		}
+	}
+
+	// Match DROP and ADD columns
+	// Strategy: For each DROP, find the best matching ADD using:
+	// 1. Same position (if available)
+	// 2. Matching type
+	// 3. Name similarity as tiebreaker
+	//
+	// To avoid greedy algorithm issues, we first score all potential matches,
+	// then sort DROP columns by match quality (best matches first) to ensure
+	// unambiguous renames are matched before ambiguous ones
+	type matchCandidate struct {
+		dropIdx     int
+		addIdx      int
+		score       float64
+		similarity  float64
+		posMatch    bool
+	}
+
+	var candidates []matchCandidate
+	for i, dropPosDiff := range dropDiffs {
+		dropCol := dropPosDiff.diff.Current
+
+		for j, addPosDiff := range addDiffs {
+			addCol := addPosDiff.diff.Target
+
+			// Check if types match (ignoring name)
+			typeMatch := columnsEqualIgnoringName(*dropCol, *addCol)
+			if !typeMatch {
+				continue
+			}
+
+			posMatch := dropPosDiff.pos == addPosDiff.pos
+			similarity := nameSimilarity(dropPosDiff.diff.ColumnName, addPosDiff.diff.ColumnName)
+
+			// Require reasonable name similarity
+			minSimilarity := 0.53
+			if posMatch {
+				minSimilarity = 0.4
+			}
+
+			if similarity < minSimilarity {
+				continue
+			}
+
+			// Score: similarity is primary, position match is bonus
+			score := similarity * 100.0
+			if posMatch {
+				score += 3.0
+			}
+
+			candidates = append(candidates, matchCandidate{
+				dropIdx:    i,
+				addIdx:     j,
+				score:      score,
+				similarity: similarity,
+				posMatch:   posMatch,
+			})
+		}
+	}
+
+	// Sort candidates by score (best first) to match unambiguous pairs first
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		// Tiebreaker: prefer position matches
+		if candidates[i].posMatch != candidates[j].posMatch {
+			return candidates[i].posMatch
+		}
+		return candidates[i].similarity > candidates[j].similarity
+	})
+
+	var renameDiffs []ColumnDiff
+	indicesToRemove := make(map[int]bool)
+	matchedAdds := make(map[int]bool) // Track which ADD diffs have been matched
+	matchedDrops := make(map[int]bool) // Track which DROP diffs have been matched
+
+	// Process candidates in order (best matches first)
+	for _, candidate := range candidates {
+		if matchedDrops[candidate.dropIdx] || matchedAdds[candidate.addIdx] {
+			continue // Already matched
+		}
+
+		dropPosDiff := dropDiffs[candidate.dropIdx]
+		addPosDiff := addDiffs[candidate.addIdx]
+
+		// Verify the match has sufficient name similarity
+		finalSimilarity := nameSimilarity(dropPosDiff.diff.ColumnName, addPosDiff.diff.ColumnName)
+		requiredSimilarity := 0.53
+		if candidate.posMatch {
+			requiredSimilarity = 0.4
+		}
+
+		if finalSimilarity >= requiredSimilarity {
+			currentCopy := *dropPosDiff.diff.Current
+			targetCopy := *addPosDiff.diff.Target
+			renameDiffs = append(renameDiffs, ColumnDiff{
+				Type:        ColumnDiffRename,
+				ColumnName:  dropPosDiff.diff.ColumnName, // old name
+				Current:     &currentCopy,
+				Target:      &targetCopy,
+				Description: fmt.Sprintf("Rename column %s to %s", dropPosDiff.diff.ColumnName, addPosDiff.diff.ColumnName),
+			})
+
+			// Mark original diffs for removal
+			indicesToRemove[dropPosDiff.idx] = true
+			indicesToRemove[addPosDiff.idx] = true
+			matchedAdds[candidate.addIdx] = true
+			matchedDrops[candidate.dropIdx] = true
+		}
+	}
+
+	// Remove matched ADD/DROP diffs and add RENAME diffs
+	if len(indicesToRemove) > 0 {
+		// Build sorted list of indices to remove (descending order)
+		sortedIndices := make([]int, 0, len(indicesToRemove))
+		for idx := range indicesToRemove {
+			sortedIndices = append(sortedIndices, idx)
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(sortedIndices)))
+
+		// Remove indices from highest to lowest to avoid index shifting issues
+		for _, idx := range sortedIndices {
+			diffs = append(diffs[:idx], diffs[idx+1:]...)
+		}
+
+		// Add RENAME diffs
+		diffs = append(diffs, renameDiffs...)
+	}
+
 	return diffs
+}
+
+// columnsEqualIgnoringName compares two columns for equality, ignoring the name
+// For rename detection, we only care about the DataType matching - other attributes
+// like Default, Codec, TTL, Comment, DefaultType might differ but shouldn't prevent renames
+func columnsEqualIgnoringName(a, b ColumnInfo) bool {
+	// Only compare DataType - ignore name, Default, Codec, TTL, Comment, DefaultType
+	// This ensures that columns with the same type but different metadata can still be renamed
+	return equalAST(a.DataType, b.DataType)
+}
+
+// nameSimilarity calculates a simple similarity score between two column names
+// Returns a value between 0.0 and 1.0, where 1.0 is identical
+// Uses word-based matching and longest common subsequence
+func nameSimilarity(name1, name2 string) float64 {
+	if name1 == name2 {
+		return 1.0
+	}
+	if len(name1) == 0 || len(name2) == 0 {
+		return 0.0
+	}
+
+	// Split names by underscores to get words
+	words1 := strings.Split(name1, "_")
+	words2 := strings.Split(name2, "_")
+
+	// Calculate word overlap (more important for column names)
+	wordOverlap := 0.0
+	matchedWords := 0
+	totalWords := len(words1)
+	if len(words2) > totalWords {
+		totalWords = len(words2)
+	}
+
+	// Count matching words (order-independent)
+	words2Map := make(map[string]int)
+	for _, w := range words2 {
+		words2Map[w]++
+	}
+
+	for _, w1 := range words1 {
+		if count, exists := words2Map[w1]; exists && count > 0 {
+			matchedWords++
+			words2Map[w1]--
+		}
+	}
+
+	if totalWords > 0 {
+		wordOverlap = float64(matchedWords) / float64(totalWords)
+	}
+
+	// Also calculate LCS for partial matches
+	lcsLen := longestCommonSubsequence(name1, name2)
+	maxLen := len(name1)
+	if len(name2) > maxLen {
+		maxLen = len(name2)
+	}
+	lcsRatio := float64(lcsLen) / float64(maxLen)
+
+	// Weight word overlap much more heavily (80%) since column names are word-based
+	// LCS helps with partial word matches (20%)
+	return 0.8*wordOverlap + 0.2*lcsRatio
+}
+
+// longestCommonSubsequence calculates the length of the longest common subsequence
+func longestCommonSubsequence(s1, s2 string) int {
+	m, n := len(s1), len(s2)
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if s1[i-1] == s2[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else {
+				if dp[i-1][j] > dp[i][j-1] {
+					dp[i][j] = dp[i-1][j]
+				} else {
+					dp[i][j] = dp[i][j-1]
+				}
+			}
+		}
+	}
+	return dp[m][n]
+}
+
+// isIncompatibleAggregateFunctionChange checks if changing from currentType to targetType
+// involves an incompatible AggregateFunction type change that ClickHouse doesn't support via MODIFY.
+// ClickHouse cannot MODIFY AggregateFunction columns when the aggregate function itself changes
+// (e.g., from groupUniqArrayArray to argMaxIf). Such changes require DROP + ADD instead.
+func isIncompatibleAggregateFunctionChange(currentType, targetType *parser.DataType) bool {
+	if currentType == nil || targetType == nil {
+		return false
+	}
+
+	currentStr := currentType.String()
+	targetStr := targetType.String()
+
+	// Check if both are AggregateFunction or SimpleAggregateFunction types
+	isCurrentAggregate := strings.Contains(currentStr, "AggregateFunction") || strings.Contains(currentStr, "SimpleAggregateFunction")
+	isTargetAggregate := strings.Contains(targetStr, "AggregateFunction") || strings.Contains(targetStr, "SimpleAggregateFunction")
+
+	if !isCurrentAggregate || !isTargetAggregate {
+		return false // Not both aggregate functions, MODIFY should work
+	}
+
+	// Extract the aggregate function name (first parameter)
+	// AggregateFunction(funcName, ...) or SimpleAggregateFunction(funcName, ...)
+	currentFunc := extractAggregateFunctionName(currentStr)
+	targetFunc := extractAggregateFunctionName(targetStr)
+
+	// If the function names are different, it's an incompatible change
+	if currentFunc != "" && targetFunc != "" && currentFunc != targetFunc {
+		return true
+	}
+
+	// Also check if switching between AggregateFunction and SimpleAggregateFunction
+	if strings.HasPrefix(currentStr, "AggregateFunction") && strings.HasPrefix(targetStr, "SimpleAggregateFunction") {
+		return true
+	}
+	if strings.HasPrefix(currentStr, "SimpleAggregateFunction") && strings.HasPrefix(targetStr, "AggregateFunction") {
+		return true
+	}
+
+	return false
+}
+
+// extractAggregateFunctionName extracts the aggregate function name from a type string
+// e.g., "AggregateFunction(groupUniqArrayArray, Array(String))" -> "groupUniqArrayArray"
+// e.g., "SimpleAggregateFunction(max, Nullable(Decimal(18, 2)))" -> "max"
+func extractAggregateFunctionName(typeStr string) string {
+	// Find the opening parenthesis after AggregateFunction or SimpleAggregateFunction
+	openParen := strings.Index(typeStr, "(")
+	if openParen == -1 {
+		return ""
+	}
+
+	// Extract the function name (first parameter before the first comma or closing paren)
+	funcPart := typeStr[openParen+1:]
+	// Find the first comma or closing paren
+	commaIdx := strings.Index(funcPart, ",")
+	closeParenIdx := strings.Index(funcPart, ")")
+
+	endIdx := len(funcPart)
+	if commaIdx != -1 && commaIdx < endIdx {
+		endIdx = commaIdx
+	}
+	if closeParenIdx != -1 && closeParenIdx < endIdx {
+		endIdx = closeParenIdx
+	}
+
+	funcName := strings.TrimSpace(funcPart[:endIdx])
+	return funcName
 }
 
 // reverseColumnChanges reverses column changes for down migration
@@ -830,6 +1167,17 @@ func reverseColumnChanges(changes []ColumnDiff) []ColumnDiff {
 				Current:     &currentCopy,
 				Target:      &targetCopy,
 				Description: "Modify column " + change.ColumnName,
+			})
+		case ColumnDiffRename:
+			// Reverse rename: new -> old becomes old -> new
+			currentCopy := *change.Target
+			targetCopy := *change.Current
+			reversed = append(reversed, ColumnDiff{
+				Type:        ColumnDiffRename,
+				ColumnName:  change.Target.Name, // new name becomes old
+				Current:     &currentCopy,
+				Target:      &targetCopy,
+				Description: fmt.Sprintf("Rename column %s to %s", change.Target.Name, change.ColumnName),
 			})
 		}
 	}
@@ -1046,6 +1394,12 @@ func generateAlterTableSQL(current, target *TableInfo, columnChanges []ColumnDif
 		case ColumnDiffModify:
 			sql.WriteString("MODIFY COLUMN ")
 			sql.WriteString(formatColumnDefinition(*change.Target))
+		case ColumnDiffRename:
+			sql.WriteString("RENAME COLUMN `")
+			sql.WriteString(change.ColumnName) // old name
+			sql.WriteString("` TO `")
+			sql.WriteString(change.Target.Name) // new name
+			sql.WriteString("`")
 		}
 	}
 

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -849,19 +849,17 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 
 	// Match DROP and ADD columns
 	// Strategy: For each DROP, find the best matching ADD using:
-	// 1. Same position (if available)
-	// 2. Matching type
-	// 3. Name similarity as tiebreaker
+	// 1. Same position + same type → always treat as rename (no name similarity required)
+	// 2. Otherwise: matching type + name similarity >= 0.53
 	//
-	// To avoid greedy algorithm issues, we first score all potential matches,
-	// then sort DROP columns by match quality (best matches first) to ensure
-	// unambiguous renames are matched before ambiguous ones
+	// Position+type match takes precedence so that e.g. min_event_received_at -> session_start_time
+	// at the same ordinal is detected as a rename even when names are lexically unrelated.
 	type matchCandidate struct {
-		dropIdx     int
-		addIdx      int
-		score       float64
-		similarity  float64
-		posMatch    bool
+		dropIdx    int
+		addIdx     int
+		score      float64
+		similarity float64
+		posMatch   bool
 	}
 
 	var candidates []matchCandidate
@@ -880,20 +878,17 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 			posMatch := dropPosDiff.pos == addPosDiff.pos
 			similarity := nameSimilarity(dropPosDiff.diff.ColumnName, addPosDiff.diff.ColumnName)
 
-			// Require reasonable name similarity
-			minSimilarity := 0.53
+			// Same position + same type → treat as rename regardless of name similarity
 			if posMatch {
-				minSimilarity = 0.4
-			}
-
-			if similarity < minSimilarity {
+				// No name similarity required
+			} else if similarity < 0.53 {
 				continue
 			}
 
-			// Score: similarity is primary, position match is bonus
+			// Score: position+type match first (highest), then by name similarity
 			score := similarity * 100.0
 			if posMatch {
-				score += 3.0
+				score = 1000.0 + similarity
 			}
 
 			candidates = append(candidates, matchCandidate{
@@ -920,7 +915,7 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 
 	var renameDiffs []ColumnDiff
 	indicesToRemove := make(map[int]bool)
-	matchedAdds := make(map[int]bool) // Track which ADD diffs have been matched
+	matchedAdds := make(map[int]bool)  // Track which ADD diffs have been matched
 	matchedDrops := make(map[int]bool) // Track which DROP diffs have been matched
 
 	// Process candidates in order (best matches first)
@@ -932,14 +927,14 @@ func compareColumns(current, target []ColumnInfo) []ColumnDiff {
 		dropPosDiff := dropDiffs[candidate.dropIdx]
 		addPosDiff := addDiffs[candidate.addIdx]
 
-		// Verify the match has sufficient name similarity
-		finalSimilarity := nameSimilarity(dropPosDiff.diff.ColumnName, addPosDiff.diff.ColumnName)
-		requiredSimilarity := 0.53
-		if candidate.posMatch {
-			requiredSimilarity = 0.4
+		// Position+type match: accept as rename without name similarity. Otherwise require similarity >= 0.53.
+		accept := candidate.posMatch
+		if !accept {
+			finalSimilarity := nameSimilarity(dropPosDiff.diff.ColumnName, addPosDiff.diff.ColumnName)
+			accept = finalSimilarity >= 0.53
 		}
 
-		if finalSimilarity >= requiredSimilarity {
+		if accept {
 			currentCopy := *dropPosDiff.diff.Current
 			targetCopy := *addPosDiff.diff.Target
 			renameDiffs = append(renameDiffs, ColumnDiff{

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -301,10 +301,24 @@ func compareTables(current, target *parser.SQL) ([]*TableDiff, error) {
 	// Pre-allocate diffs slice with estimated capacity
 	diffs := make([]*TableDiff, 0, len(currentTables)+len(targetTables))
 
+	// Pre-identify tables that will be handled via propagation to avoid duplicate diffs.
+	// When a source table has column changes, its AS dependents should be handled via propagation
+	// (which uses DROP+CREATE for view-like engines like Distributed). We skip these tables in
+	// the main loop to prevent generating both an ALTER and a DROP+CREATE for the same table.
+	// This must be done before the main loop because dependent tables may be processed
+	// before their source tables in alphabetical order.
+	propagatedTables := identifyPropagatedTables(currentTables, targetTables)
+
 	// Find tables to create or modify (exist in target but not in current) - sorted for deterministic order
 	for _, tableName := range SortedKeys(targetTables) {
 		targetTable := targetTables[tableName]
 		currentTable, exists := currentTables[tableName]
+
+		// Skip tables that will be handled via propagation from a source table
+		if propagatedTables[tableName] {
+			continue
+		}
+
 		diff, err := createTableDiff(tableName, currentTable, targetTable, currentTables, targetTables, exists)
 		if err != nil {
 			return nil, err
@@ -346,6 +360,51 @@ func compareTables(current, target *parser.SQL) ([]*TableDiff, error) {
 	}
 
 	return diffs, nil
+}
+
+// identifyPropagatedTables pre-identifies tables that should be handled via propagation
+// rather than the main comparison loop. This is necessary because dependent tables may be
+// processed before their source tables in alphabetical order.
+//
+// A table should be handled via propagation if:
+// 1. It uses AS to reference another table (is an AS dependent)
+// 2. The source table has column changes (will generate an ALTER with column changes)
+// 3. Both the source and dependent exist in current and target
+func identifyPropagatedTables(currentTables, targetTables map[string]*TableInfo) map[string]bool {
+	propagatedTables := make(map[string]bool)
+
+	for tableName, targetTable := range targetTables {
+		// Skip tables without AS dependents
+		if targetTable.AsDependents == nil || len(targetTable.AsDependents) == 0 {
+			continue
+		}
+
+		// Check if this table exists in current (required for column comparison)
+		currentTable, existsInCurrent := currentTables[tableName]
+		if !existsInCurrent {
+			continue
+		}
+
+		// Check if this table has column changes
+		// Conditionally flatten based on whether current has Nested columns
+		comparisonTargetTable := MaybeFlattenNestedColumns(currentTable, targetTable)
+		columnChanges := compareColumns(currentTable.Columns, comparisonTargetTable.Columns)
+		if len(columnChanges) == 0 {
+			continue
+		}
+
+		// This table has column changes - mark all its AS dependents for propagation
+		for dependentName := range targetTable.AsDependents {
+			// Only mark if the dependent exists in both current and target
+			if _, existsInTarget := targetTables[dependentName]; existsInTarget {
+				if _, existsInCurrent := currentTables[dependentName]; existsInCurrent {
+					propagatedTables[dependentName] = true
+				}
+			}
+		}
+	}
+
+	return propagatedTables
 }
 
 // propagateColumnChangesToDependents creates ALTER or DROP+CREATE diffs for tables

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -245,23 +245,37 @@ func (c ColumnInfo) Equal(other ColumnInfo) bool {
 		equalAST(c.TTL, other.TTL)
 }
 
-// enginesEqual compares two table engines with special handling for ReplicatedMergeTree.
-// When the target engine is ReplicatedMergeTree with no parameters, parameters are ignored
-// in the comparison. This handles the case where ClickHouse auto-expands ReplicatedMergeTree()
-// to ReplicatedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}') internally.
+// enginesEqual compares two table engines with special handling for parameter normalization.
+// This handles cases where:
+// 1. ReplicatedMergeTree() is auto-expanded by ClickHouse to include paths
+// 2. Kafka vs Kafka() are semantically equivalent (empty params vs no params)
 func enginesEqual(target, current *parser.TableEngine) bool {
 	// Use standard equalAST for nil checks
 	if target == nil || current == nil {
 		return equalAST(target, current)
 	}
 
-	// Special handling for ReplicatedMergeTree when target has no parameters
-	if target.Name == "ReplicatedMergeTree" && len(target.Parameters) == 0 {
-		// If target has no parameters, only compare engine names (ignore current parameters)
-		return current.Name == "ReplicatedMergeTree"
+	// Engine names must match
+	if target.Name != current.Name {
+		return false
 	}
 
-	// For all other cases (including ReplicatedMergeTree with explicit parameters), use standard AST comparison
+	// Special handling for ReplicatedMergeTree when target has no parameters
+	// ClickHouse auto-expands ReplicatedMergeTree() to include paths like
+	// ReplicatedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+	if target.Name == "ReplicatedMergeTree" && len(target.Parameters) == 0 {
+		return true // Names match and target has no params, consider equal
+	}
+
+	// For engines where empty params are equivalent to no params (Kafka, etc.)
+	// Treat nil and empty slice as equivalent
+	targetEmpty := len(target.Parameters) == 0
+	currentEmpty := len(current.Parameters) == 0
+	if targetEmpty && currentEmpty {
+		return true
+	}
+
+	// For all other cases, use standard AST comparison
 	return equalAST(target, current)
 }
 
@@ -637,9 +651,9 @@ func findRenamedTable(targetTable *TableInfo, currentTables, targetTables map[st
 		}
 
 		// Compare table properties (excluding name and database)
-		// Use flattened target table for comparison
-		flattenedTargetTable := FlattenNestedColumns(targetTable)
-		if tablesEqualIgnoringName(currentTable, flattenedTargetTable) {
+		// Conditionally flatten target table based on whether current has Nested columns
+		comparisonTargetTable := MaybeFlattenNestedColumns(currentTable, targetTable)
+		if tablesEqualIgnoringName(currentTable, comparisonTargetTable) {
 			return currentName
 		}
 	}
@@ -1027,10 +1041,10 @@ func handleTableNotExists(tableName string, targetTable *TableInfo, currentTable
 // Otherwise, column-level differences are computed and an ALTER operation is generated.
 func handleTableExists(tableName string, currentTable, targetTable *TableInfo) (*TableDiff, error) {
 	// Table exists in both - check for changes
-	// For comparison purposes, flatten the target table to match ClickHouse's internal representation
-	// Current table is already flattened by ClickHouse, but target table may have Nested syntax
-	flattenedTargetTable := FlattenNestedColumns(targetTable)
-	if tablesEqual(currentTable, flattenedTargetTable) {
+	// Conditionally flatten target table based on whether ClickHouse has flatten_nested=0
+	// If current table has Nested columns, keep target as-is; otherwise flatten to match
+	comparisonTargetTable := MaybeFlattenNestedColumns(currentTable, targetTable)
+	if tablesEqual(currentTable, comparisonTargetTable) {
 		return nil, nil
 	}
 
@@ -1040,8 +1054,8 @@ func handleTableExists(tableName string, currentTable, targetTable *TableInfo) (
 	}
 
 	// Generate column diffs for regular tables
-	// Use flattened target table for comparison but preserve original for SQL generation
-	columnChanges := compareColumns(currentTable.Columns, flattenedTargetTable.Columns)
+	// Use comparison target table (may be flattened or not depending on ClickHouse setting)
+	columnChanges := compareColumns(currentTable.Columns, comparisonTargetTable.Columns)
 
 	return createAlterDiff(tableName, currentTable, targetTable, columnChanges), nil
 }

--- a/pkg/schema/table_test.go
+++ b/pkg/schema/table_test.go
@@ -112,3 +112,116 @@ func TestTableInfoEqual(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// dateTime64Type returns a parser DataType for DateTime64(6, 'UTC') for use in tests.
+func dateTime64Type() *parser.DataType {
+	return &parser.DataType{
+		Simple: &parser.SimpleType{
+			Name:       "DateTime64",
+			Parameters: []parser.TypeParameter{{Number: stringPtr("6")}, {String: stringPtr("'UTC'")}},
+		},
+	}
+}
+
+func TestCompareColumns_RenameDetectedByPositionAndTypeOnly(t *testing.T) {
+	// Same position + same type → rename detected even with zero name similarity
+	// (e.g. min_event_received_at -> session_start_time)
+	dateType := dateTime64Type()
+	current := []ColumnInfo{
+		{Name: "min_event_received_at", DataType: dateType},
+		{Name: "max_event_received_at", DataType: dateType},
+	}
+	target := []ColumnInfo{
+		{Name: "session_start_time", DataType: dateType},
+		{Name: "session_end_time", DataType: dateType},
+	}
+
+	diffs := compareColumns(current, target)
+
+	var renames []ColumnDiff
+	for _, d := range diffs {
+		if d.Type == ColumnDiffRename {
+			renames = append(renames, d)
+		}
+	}
+	require.Len(t, renames, 2, "expected 2 renames when position and type match")
+	require.Equal(t, "min_event_received_at", renames[0].ColumnName)
+	require.Equal(t, "session_start_time", renames[0].Target.Name)
+	require.Equal(t, "max_event_received_at", renames[1].ColumnName)
+	require.Equal(t, "session_end_time", renames[1].Target.Name)
+}
+
+func TestCompareColumns_RenameDetectedSamePositionSameTypeUnrelatedNames(t *testing.T) {
+	// Same position, same type, completely unrelated names (foo, bar) → still rename
+	uintType := &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}
+	current := []ColumnInfo{
+		{Name: "foo", DataType: uintType},
+	}
+	target := []ColumnInfo{
+		{Name: "bar", DataType: uintType},
+	}
+
+	diffs := compareColumns(current, target)
+
+	require.Len(t, diffs, 1)
+	require.Equal(t, ColumnDiffRename, diffs[0].Type)
+	require.Equal(t, "foo", diffs[0].ColumnName)
+	require.Equal(t, "bar", diffs[0].Target.Name)
+}
+
+func TestCompareColumns_NoRenameWhenPositionDifferentSameType(t *testing.T) {
+	// Different position, same type, low name similarity → ADD + DROP, not RENAME
+	uintType := &parser.DataType{Simple: &parser.SimpleType{Name: "UInt64"}}
+	current := []ColumnInfo{
+		{Name: "a", DataType: uintType},
+		{Name: "b", DataType: uintType},
+	}
+	target := []ColumnInfo{
+		{Name: "x", DataType: uintType},
+		{Name: "b", DataType: uintType},
+		{Name: "y", DataType: uintType},
+	}
+	// Current: a(0), b(1). Target: x(0), b(1), y(2).
+	// So we have DROP a, ADD x, ADD y. Position: a at 0, x at 0, y at 2.
+	// Type match: a-x (both UInt64), a-y (both UInt64). Position: a-x match (0==0), a-y no (0!=2).
+	// So a-x should match as rename (position+type). Then we have DROP nothing, ADD y. So one RENAME a->x, one ADD y.
+	diffs := compareColumns(current, target)
+
+	var renames []ColumnDiff
+	var adds []ColumnDiff
+	for _, d := range diffs {
+		switch d.Type {
+		case ColumnDiffRename:
+			renames = append(renames, d)
+		case ColumnDiffAdd:
+			adds = append(adds, d)
+		}
+	}
+	// a(0) and x(0) same type → rename. b exists in both. y(2) is new → ADD.
+	require.Len(t, renames, 1, "only a->x should be rename (same position 0)")
+	require.Equal(t, "a", renames[0].ColumnName)
+	require.Equal(t, "x", renames[0].Target.Name)
+	require.Len(t, adds, 1)
+	require.Equal(t, "y", adds[0].ColumnName)
+}
+
+func TestCompareColumns_NoRenameWhenTypeDifferentSamePosition(t *testing.T) {
+	// Same position, different type → ADD + DROP, not RENAME
+	current := []ColumnInfo{
+		{Name: "ts", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "DateTime"}}},
+	}
+	target := []ColumnInfo{
+		{Name: "ts_utc", DataType: &parser.DataType{Simple: &parser.SimpleType{Name: "DateTime64", Parameters: []parser.TypeParameter{{Number: stringPtr("6")}}}}},
+	}
+
+	diffs := compareColumns(current, target)
+
+	var renames []ColumnDiff
+	for _, d := range diffs {
+		if d.Type == ColumnDiffRename {
+			renames = append(renames, d)
+		}
+	}
+	require.Len(t, renames, 0, "different type should not produce rename")
+	require.GreaterOrEqual(t, len(diffs), 1)
+}

--- a/pkg/schema/testdata/distributed_as_column_propagation.in.sql
+++ b/pkg/schema/testdata/distributed_as_column_propagation.in.sql
@@ -1,0 +1,24 @@
+-- Test case: Distributed table using AS should get DROP+CREATE via propagation (not ALTER from main loop)
+-- This prevents duplicate diffs for the same Distributed table when the source table has column changes
+-- Current state: local table and distributed table without the new column
+CREATE TABLE analytics.events_local (
+    id UInt64,
+    timestamp DateTime,
+    name String
+) ENGINE = MergeTree()
+ORDER BY (id, timestamp);
+
+CREATE TABLE analytics.events AS analytics.events_local
+ENGINE = Distributed('cluster', 'analytics', 'events_local', rand());
+
+-- Target state: local table has a new column, distributed table should be recreated to match
+CREATE TABLE analytics.events_local (
+    id UInt64,
+    timestamp DateTime,
+    name String,
+    clicked_text String
+) ENGINE = MergeTree()
+ORDER BY (id, timestamp);
+
+CREATE TABLE analytics.events AS analytics.events_local
+ENGINE = Distributed('cluster', 'analytics', 'events_local', rand());

--- a/pkg/schema/testdata/distributed_as_column_propagation.sql
+++ b/pkg/schema/testdata/distributed_as_column_propagation.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `analytics`.`events_local`
+    ADD COLUMN `clicked_text` String;
+
+-- Recreate to match schema changes from analytics.events_local
+
+DROP TABLE `analytics`.`events`;
+
+CREATE TABLE `analytics`.`events` (
+    `id`           UInt64,
+    `timestamp`    DateTime,
+    `name`         String,
+    `clicked_text` String
+)
+ENGINE = Distributed('cluster', 'analytics', 'events_local', rand());

--- a/pkg/schema/utils.go
+++ b/pkg/schema/utils.go
@@ -108,6 +108,9 @@ func normalizedExpressionsEqual(expr1, expr2 *parser.Expression) bool {
 func normalizeExpressionString(expr string) string {
 	result := expr
 
+	// Normalize identifier quoting: strip backticks so dump (e.g. `r`.`ws_path`) matches schema (r.ws_path)
+	result = strings.ReplaceAll(result, "`", "")
+
 	// Normalize INTERVAL to toInterval function format
 	intervalUnits := map[string]string{
 		"SECOND":  "Second",
@@ -131,12 +134,106 @@ func normalizeExpressionString(expr string) string {
 	result = regexp.MustCompile(`\s+`).ReplaceAllString(result, " ")
 	result = strings.TrimSpace(result)
 
+	// Normalize IN (single_identifier) to IN identifier (ClickHouse wraps CTE refs in parens)
+	result = regexp.MustCompile(`\s+NOT\s+IN\s+\(\s*([a-zA-Z0-9_]+)\s*\)`).ReplaceAllString(result, " NOT IN $1")
+	result = regexp.MustCompile(`\s+IN\s+\(\s*([a-zA-Z0-9_]+)\s*\)`).ReplaceAllString(result, " IN $1")
+
+	// Strip outer balanced parentheses so "(expr)" and "expr" normalize the same
+	result = removeOuterBalancedParens(result)
+
 	// Remove redundant parentheses around simple expressions
 	// Pattern: match expressions like "(now() - toIntervalDay(1))" and keep the inner part
 	// But be careful not to remove parentheses that are part of function calls or tuples
 	result = removeRedundantParens(result)
 
+	// Strip outer parens from each top-level AND/OR segment so "((id, name) NOT IN pending)" -> "(id, name) NOT IN pending"
+	result = stripOuterParensPerSegment(result)
+
 	return result
+}
+
+// stripOuterParensPerSegment splits on top-level " AND " / " OR ", strips outer balanced parens from each segment, rejoins.
+func stripOuterParensPerSegment(s string) string {
+	segments, delims := splitTopLevelAndOr(s)
+	var b strings.Builder
+	for i, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		for {
+			next := removeOuterBalancedParens(seg)
+			if next == seg {
+				break
+			}
+			seg = next
+		}
+		if i > 0 {
+			b.WriteString(delims[i-1])
+		}
+		b.WriteString(seg)
+	}
+	return b.String()
+}
+
+// splitTopLevelAndOr splits s by " AND " and " OR " at paren depth 0. Returns segments and delimiters (len(delims) = len(segments)-1).
+func splitTopLevelAndOr(s string) (segments []string, delims []string) {
+	start := 0
+	depth := 0
+	i := 0
+	for i < len(s) {
+		switch s[i] {
+		case '(':
+			depth++
+			i++
+		case ')':
+			depth--
+			i++
+		case ' ':
+			if depth == 0 {
+				if i+5 <= len(s) && s[i+1:i+5] == "AND " {
+					segments = append(segments, s[start:i])
+					delims = append(delims, " AND ")
+					start = i + 5
+					i += 5
+					continue
+				}
+				if i+4 <= len(s) && s[i+1:i+4] == "OR " {
+					segments = append(segments, s[start:i])
+					delims = append(delims, " OR ")
+					start = i + 4
+					i += 4
+					continue
+				}
+			}
+			i++
+		default:
+			i++
+		}
+	}
+	segments = append(segments, s[start:])
+	return segments, delims
+}
+
+// removeOuterBalancedParens strips outermost balanced parentheses repeatedly.
+// So "( (a) AND (b) )" becomes "(a) AND (b)", and "(ts < (x - y))" becomes "ts < (x - y)".
+func removeOuterBalancedParens(s string) string {
+	for {
+		s = strings.TrimSpace(s)
+		if len(s) < 2 || s[0] != '(' || s[len(s)-1] != ')' {
+			return s
+		}
+		// Check that the closing ')' at end is the match for the opening '(' at start
+		depth := 1
+		for i := 1; i < len(s)-1; i++ {
+			if s[i] == '(' {
+				depth++
+			} else if s[i] == ')' {
+				depth--
+				if depth == 0 {
+					return s // inner ')' closed the opening '(', so outer parens are not balanced
+				}
+			}
+		}
+		s = strings.TrimSpace(s[1 : len(s)-1])
+	}
 }
 
 // removeRedundantParens removes redundant parentheses from expressions

--- a/pkg/schema/utils_test.go
+++ b/pkg/schema/utils_test.go
@@ -1,0 +1,444 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no backticks",
+			input:    "column_name",
+			expected: "column_name",
+		},
+		{
+			name:     "with backticks",
+			input:    "`column_name`",
+			expected: "column_name",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single character",
+			input:    "a",
+			expected: "a",
+		},
+		{
+			name:     "single backtick start only",
+			input:    "`name",
+			expected: "`name",
+		},
+		{
+			name:     "single backtick end only",
+			input:    "name`",
+			expected: "name`",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeIdentifier(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIdentifiersEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		id1      *parser.IdentifierExpr
+		id2      *parser.IdentifierExpr
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			id1:      nil,
+			id2:      nil,
+			expected: true,
+		},
+		{
+			name:     "first nil",
+			id1:      nil,
+			id2:      &parser.IdentifierExpr{Name: "column"},
+			expected: false,
+		},
+		{
+			name:     "second nil",
+			id1:      &parser.IdentifierExpr{Name: "column"},
+			id2:      nil,
+			expected: false,
+		},
+		{
+			name:     "equal simple names",
+			id1:      &parser.IdentifierExpr{Name: "column"},
+			id2:      &parser.IdentifierExpr{Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "equal names case insensitive",
+			id1:      &parser.IdentifierExpr{Name: "Column"},
+			id2:      &parser.IdentifierExpr{Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "equal names with backticks on first",
+			id1:      &parser.IdentifierExpr{Name: "`column`"},
+			id2:      &parser.IdentifierExpr{Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "equal names with backticks on second",
+			id1:      &parser.IdentifierExpr{Name: "column"},
+			id2:      &parser.IdentifierExpr{Name: "`column`"},
+			expected: true,
+		},
+		{
+			name:     "equal names with backticks on both",
+			id1:      &parser.IdentifierExpr{Name: "`column`"},
+			id2:      &parser.IdentifierExpr{Name: "`column`"},
+			expected: true,
+		},
+		{
+			name:     "backticks with case difference",
+			id1:      &parser.IdentifierExpr{Name: "`Column`"},
+			id2:      &parser.IdentifierExpr{Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "different names",
+			id1:      &parser.IdentifierExpr{Name: "column1"},
+			id2:      &parser.IdentifierExpr{Name: "column2"},
+			expected: false,
+		},
+		{
+			name:     "different names with backticks",
+			id1:      &parser.IdentifierExpr{Name: "`column1`"},
+			id2:      &parser.IdentifierExpr{Name: "`column2`"},
+			expected: false,
+		},
+		{
+			name:     "equal with database qualifier",
+			id1:      &parser.IdentifierExpr{Database: stringPtr("db"), Name: "column"},
+			id2:      &parser.IdentifierExpr{Database: stringPtr("db"), Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "equal with database qualifier backticks",
+			id1:      &parser.IdentifierExpr{Database: stringPtr("`db`"), Name: "`column`"},
+			id2:      &parser.IdentifierExpr{Database: stringPtr("db"), Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "different database qualifiers",
+			id1:      &parser.IdentifierExpr{Database: stringPtr("db1"), Name: "column"},
+			id2:      &parser.IdentifierExpr{Database: stringPtr("db2"), Name: "column"},
+			expected: false,
+		},
+		{
+			name:     "one with database qualifier one without",
+			id1:      &parser.IdentifierExpr{Database: stringPtr("db"), Name: "column"},
+			id2:      &parser.IdentifierExpr{Name: "column"},
+			expected: false,
+		},
+		{
+			name:     "equal with table qualifier",
+			id1:      &parser.IdentifierExpr{Table: stringPtr("tbl"), Name: "column"},
+			id2:      &parser.IdentifierExpr{Table: stringPtr("tbl"), Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "equal with table qualifier backticks",
+			id1:      &parser.IdentifierExpr{Table: stringPtr("`tbl`"), Name: "`column`"},
+			id2:      &parser.IdentifierExpr{Table: stringPtr("tbl"), Name: "column"},
+			expected: true,
+		},
+		{
+			name:     "full qualification with backticks",
+			id1:      &parser.IdentifierExpr{Database: stringPtr("`db`"), Table: stringPtr("`tbl`"), Name: "`column`"},
+			id2:      &parser.IdentifierExpr{Database: stringPtr("db"), Table: stringPtr("tbl"), Name: "column"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := identifiersEqual(tt.id1, tt.id2)
+			require.Equal(t, tt.expected, result, "identifiersEqual(%v, %v) = %v, want %v", tt.id1, tt.id2, result, tt.expected)
+		})
+	}
+}
+
+// TestViewBacktickNormalization tests that views with backticks in identifiers
+// are correctly compared as equal to views without backticks.
+// ClickHouse stores views with backticks but users typically write them without.
+func TestViewBacktickNormalization(t *testing.T) {
+	// View without backticks (user schema file)
+	schemaSQL := `CREATE MATERIALIZED VIEW mydb.my_view ON CLUSTER mycluster
+REFRESH EVERY 10 SECONDS
+APPEND TO mydb.target_table
+AS
+WITH pending AS (SELECT id, name FROM mydb.source_table GROUP BY id, name HAVING max(status) = 1 LIMIT 1000)
+SELECT id, name FROM mydb.data_table WHERE (id, name) IN pending GROUP BY id, name;`
+
+	// View with backticks (ClickHouse output)
+	clickhouseSQL := "CREATE MATERIALIZED VIEW `mydb`.`my_view` ON CLUSTER `mycluster` " +
+		"REFRESH EVERY 10 SECONDS " +
+		"APPEND TO `mydb`.`target_table` " +
+		"AS " +
+		"WITH `pending` AS (SELECT `id`, `name` FROM `mydb`.`source_table` GROUP BY `id`, `name` HAVING max(`status`) = 1 LIMIT 1000) " +
+		"SELECT `id`, `name` FROM `mydb`.`data_table` WHERE (`id`, `name`) IN `pending` GROUP BY `id`, `name`;"
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err)
+	clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+	require.NoError(t, err)
+
+	schemaViews := extractViewsFromSQL(schemaParsed)
+	clickhouseViews := extractViewsFromSQL(clickhouseParsed)
+
+	schemaView := schemaViews["mydb.my_view"]
+	clickhouseView := clickhouseViews["mydb.my_view"]
+
+	require.NotNil(t, schemaView)
+	require.NotNil(t, clickhouseView)
+
+	equal := viewsAreEqual(clickhouseView, schemaView)
+	require.True(t, equal, "views should be equal despite backtick differences")
+}
+
+// TestINExpressionWithParentheses tests that IN expressions with and without parentheses
+// around the CTE reference are considered equal.
+// ClickHouse wraps CTE references in parentheses: IN (cte_name) vs IN cte_name
+func TestINExpressionWithParentheses(t *testing.T) {
+	withParens := `SELECT * FROM t WHERE (a, b) IN (my_cte);`
+	withoutParens := `SELECT * FROM t WHERE (a, b) IN my_cte;`
+
+	parsedWith, err := parser.ParseString(withParens)
+	require.NoError(t, err)
+	parsedWithout, err := parser.ParseString(withoutParens)
+	require.NoError(t, err)
+
+	selectWith := parsedWith.Statements[0].SelectStatement
+	selectWithout := parsedWithout.Statements[0].SelectStatement
+
+	equal := selectStatementsAreEqualAST(&selectWith.SelectStatement, &selectWithout.SelectStatement)
+	require.True(t, equal, "IN (cte) and IN cte should be considered equal")
+}
+
+// TestNOTINExpressionWithParentheses tests that NOT IN expressions work like IN expressions
+func TestNOTINExpressionWithParentheses(t *testing.T) {
+	withParens := `SELECT * FROM t WHERE (a, b) NOT IN (my_cte);`
+	withoutParens := `SELECT * FROM t WHERE (a, b) NOT IN my_cte;`
+
+	parsedWith, err := parser.ParseString(withParens)
+	require.NoError(t, err)
+	parsedWithout, err := parser.ParseString(withoutParens)
+	require.NoError(t, err)
+
+	selectWith := parsedWith.Statements[0].SelectStatement
+	selectWithout := parsedWithout.Statements[0].SelectStatement
+
+	equal := selectStatementsAreEqualAST(&selectWith.SelectStatement, &selectWithout.SelectStatement)
+	require.True(t, equal, "NOT IN (cte) and NOT IN cte should be considered equal")
+}
+
+// TestTimeUnitNormalization tests that SECOND/SECONDS and other time units
+// are treated as equivalent (singular vs plural).
+func TestTimeUnitNormalization(t *testing.T) {
+	tests := []struct {
+		name     string
+		unit1    string
+		unit2    string
+		expected bool
+	}{
+		{"SECOND equals SECONDS", "SECOND", "SECONDS", true},
+		{"SECONDS equals SECOND", "SECONDS", "SECOND", true},
+		{"MINUTE equals MINUTES", "MINUTE", "MINUTES", true},
+		{"HOUR equals HOURS", "HOUR", "HOURS", true},
+		{"DAY equals DAYS", "DAY", "DAYS", true},
+		{"case insensitive", "second", "SECONDS", true},
+		{"different units", "SECOND", "MINUTE", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := timeUnitsAreEqual(tt.unit1, tt.unit2)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestRefreshIntervalNormalization tests that equivalent refresh intervals
+// are considered equal (e.g., 60 SECOND == 1 MINUTE).
+func TestRefreshIntervalNormalization(t *testing.T) {
+	// Schema: REFRESH EVERY 60 SECONDS
+	schemaSQL := `CREATE MATERIALIZED VIEW mydb.my_view
+REFRESH EVERY 60 SECONDS
+APPEND TO mydb.target
+AS SELECT id FROM mydb.source;`
+
+	// ClickHouse normalizes to: REFRESH EVERY 1 MINUTE
+	clickhouseSQL := `CREATE MATERIALIZED VIEW mydb.my_view
+REFRESH EVERY 1 MINUTE
+APPEND TO mydb.target
+AS SELECT id FROM mydb.source;`
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err)
+	clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+	require.NoError(t, err)
+
+	schemaViews := extractViewsFromSQL(schemaParsed)
+	clickhouseViews := extractViewsFromSQL(clickhouseParsed)
+
+	schemaView := schemaViews["mydb.my_view"]
+	clickhouseView := clickhouseViews["mydb.my_view"]
+
+	t.Run("refresh clauses equal", func(t *testing.T) {
+		equal := refreshClausesAreEqual(schemaView.Statement.Refresh, clickhouseView.Statement.Refresh)
+		require.True(t, equal, "60 SECONDS and 1 MINUTE should be equal")
+	})
+
+	t.Run("full view comparison", func(t *testing.T) {
+		equal := viewsAreEqual(clickhouseView, schemaView)
+		require.True(t, equal)
+	})
+}
+
+// TestIntervalVsToIntervalFunction tests that INTERVAL expressions are considered
+// equal to their toIntervalXxx() function equivalents.
+// ClickHouse converts "INTERVAL 3 HOUR" to "toIntervalHour(3)".
+func TestIntervalVsToIntervalFunction(t *testing.T) {
+	// Schema uses INTERVAL syntax in a view
+	schemaSQL := `CREATE MATERIALIZED VIEW mydb.my_view
+REFRESH EVERY 10 SECONDS APPEND TO mydb.target
+AS SELECT id FROM mydb.source WHERE ts < now() - INTERVAL 3 HOUR;`
+
+	// ClickHouse converts to function call
+	clickhouseSQL := `CREATE MATERIALIZED VIEW mydb.my_view
+REFRESH EVERY 10 SECONDS APPEND TO mydb.target
+AS SELECT id FROM mydb.source WHERE ts < now() - toIntervalHour(3);`
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err)
+	clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+	require.NoError(t, err)
+
+	schemaViews := extractViewsFromSQL(schemaParsed)
+	clickhouseViews := extractViewsFromSQL(clickhouseParsed)
+
+	schemaView := schemaViews["mydb.my_view"]
+	clickhouseView := clickhouseViews["mydb.my_view"]
+
+	equal := viewsAreEqual(clickhouseView, schemaView)
+	require.True(t, equal, "INTERVAL 3 HOUR and toIntervalHour(3) should be equal")
+}
+
+// TestClusterIgnoredInComparison tests that ON CLUSTER is ignored when comparing views.
+// ClickHouse doesn't return ON CLUSTER in create_table_query from system.tables.
+func TestClusterIgnoredInComparison(t *testing.T) {
+	// Schema has ON CLUSTER
+	schemaSQL := `CREATE MATERIALIZED VIEW mydb.my_view ON CLUSTER mycluster
+REFRESH EVERY 10 SECONDS
+APPEND TO mydb.target
+AS SELECT id FROM mydb.source;`
+
+	// ClickHouse output doesn't have ON CLUSTER
+	clickhouseSQL := `CREATE MATERIALIZED VIEW mydb.my_view
+REFRESH EVERY 10 SECONDS
+APPEND TO mydb.target
+AS SELECT id FROM mydb.source;`
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err)
+	clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+	require.NoError(t, err)
+
+	schemaViews := extractViewsFromSQL(schemaParsed)
+	clickhouseViews := extractViewsFromSQL(clickhouseParsed)
+
+	schemaView := schemaViews["mydb.my_view"]
+	clickhouseView := clickhouseViews["mydb.my_view"]
+
+	require.NotNil(t, schemaView)
+	require.NotNil(t, clickhouseView)
+
+	// Verify clusters are different
+	require.Equal(t, "mycluster", schemaView.Cluster)
+	require.Equal(t, "", clickhouseView.Cluster)
+
+	// But views should still be considered equal
+	equal := viewsAreEqual(clickhouseView, schemaView)
+	require.True(t, equal, "views should be equal even with different cluster settings")
+}
+
+// TestCompleteClickHouseNormalization tests all ClickHouse normalizations together:
+// - Backticks
+// - 60 SECOND -> 1 MINUTE
+// - INTERVAL -> toIntervalXxx()
+// - IN cte -> IN (cte)
+// - Missing ON CLUSTER
+func TestCompleteClickHouseNormalization(t *testing.T) {
+	// User's schema file
+	schemaSQL := `CREATE MATERIALIZED VIEW mydb.my_view ON CLUSTER mycluster
+REFRESH EVERY 60 SECOND APPEND TO mydb.target
+AS
+WITH pending AS (
+    SELECT DISTINCT id, name FROM mydb.lifecycle WHERE status = 'done'
+)
+SELECT id, name, 'done' AS status, now64(3, 'UTC') AS ts
+FROM mydb.source
+WHERE ts < now64(3, 'UTC') - INTERVAL 3 HOUR
+  AND (id, name) NOT IN pending
+LIMIT 1000;`
+
+	// ClickHouse output after cleanViewStatement (DEFINER and column defs stripped)
+	clickhouseSQL := `CREATE MATERIALIZED VIEW mydb.my_view
+REFRESH EVERY 1 MINUTE APPEND TO mydb.target
+AS WITH pending AS (
+    SELECT DISTINCT id, name FROM mydb.lifecycle WHERE status = 'done'
+)
+SELECT id, name, 'done' AS status, now64(3, 'UTC') AS ts
+FROM mydb.source
+WHERE (ts < (now64(3, 'UTC') - toIntervalHour(3))) AND ((id, name) NOT IN (pending))
+LIMIT 1000;`
+
+	schemaParsed, err := parser.ParseString(schemaSQL)
+	require.NoError(t, err, "Failed to parse schema SQL")
+	clickhouseParsed, err := parser.ParseString(clickhouseSQL)
+	require.NoError(t, err, "Failed to parse ClickHouse SQL")
+
+	schemaViews := extractViewsFromSQL(schemaParsed)
+	clickhouseViews := extractViewsFromSQL(clickhouseParsed)
+
+	schemaView := schemaViews["mydb.my_view"]
+	clickhouseView := clickhouseViews["mydb.my_view"]
+
+	require.NotNil(t, schemaView)
+	require.NotNil(t, clickhouseView)
+
+	t.Run("refresh interval normalization", func(t *testing.T) {
+		equal := refreshClausesAreEqual(schemaView.Statement.Refresh, clickhouseView.Statement.Refresh)
+		require.True(t, equal, "60 SECOND and 1 MINUTE should be equal")
+	})
+
+	t.Run("SELECT with all normalizations", func(t *testing.T) {
+		equal := selectClausesAreEqualWithTolerance(schemaView.Statement.AsSelect, clickhouseView.Statement.AsSelect)
+		require.True(t, equal, "SELECT statements should match after normalization")
+	})
+
+	t.Run("full view comparison", func(t *testing.T) {
+		equal := viewsAreEqual(clickhouseView, schemaView)
+		require.True(t, equal, "views should be considered equal")
+	})
+}

--- a/pkg/schema/view.go
+++ b/pkg/schema/view.go
@@ -665,6 +665,11 @@ func selectStatementsAreEqualNormalized(stmt1, stmt2 *parser.SelectStatement) bo
 	if (stmt1.With == nil) != (stmt2.With == nil) {
 		return false // Different WITH clause presence
 	}
+
+	// IMPORTANT: Always check WITH clause contents - CTE changes are meaningful
+	if !withClausesAreEqual(stmt1.With, stmt2.With) {
+		return false
+	}
 	if len(stmt1.Columns) != len(stmt2.Columns) {
 		return false // Different number of columns
 	}
@@ -675,10 +680,102 @@ func selectStatementsAreEqualNormalized(stmt1, stmt2 *parser.SelectStatement) bo
 		return false // Different ORDER BY presence
 	}
 
+	// IMPORTANT: Always check LIMIT clauses exactly - these are meaningful changes
+	if !limitClausesAreEqual(stmt1.Limit, stmt2.Limit) {
+		return false
+	}
+
+	// IMPORTANT: Always check SETTINGS clauses exactly - these are meaningful changes
+	if !settingsClausesAreEqual(stmt1.Settings, stmt2.Settings) {
+		return false
+	}
+
+	// IMPORTANT: Always check UNION clauses - these are meaningful changes
+	if !unionClausesAreEqual(stmt1.Unions, stmt2.Unions) {
+		return false
+	}
+
+	// IMPORTANT: Check WHERE clause presence (structure changes)
+	if (stmt1.Where == nil) != (stmt2.Where == nil) {
+		return false
+	}
+
+	// IMPORTANT: Check GROUP BY clause presence (structure changes)
+	if (stmt1.GroupBy == nil) != (stmt2.GroupBy == nil) {
+		return false
+	}
+
+	// IMPORTANT: Check HAVING clause presence (structure changes)
+	if (stmt1.Having == nil) != (stmt2.Having == nil) {
+		return false
+	}
+
+	// IMPORTANT: Check if FROM clause structure is significantly different
+	// (table vs subquery vs function)
+	if stmt1.From != nil && stmt2.From != nil {
+		if !fromClauseStructureSimilar(&stmt1.From.Table, &stmt2.From.Table) {
+			return false
+		}
+	}
+
 	// If we get here, the basic structure is similar
 	// For ClickHouse formatting tolerance, we'll be optimistic and assume they're equivalent
 	// This is a temporary measure to address the recreation issue
 	// TODO: Implement proper normalization comparison once format package has public methods
+	return true
+}
+
+// fromClauseStructureSimilar checks if two FROM clauses have similar structure
+// (both use table names, both use subqueries, or both use functions)
+func fromClauseStructureSimilar(table1, table2 *parser.TableRef) bool {
+	if table1 == nil && table2 == nil {
+		return true
+	}
+	if table1 == nil || table2 == nil {
+		return false
+	}
+
+	// Check if both use table names
+	if (table1.TableName != nil) != (table2.TableName != nil) {
+		return false
+	}
+
+	// Check if both use subqueries
+	if (table1.Subquery != nil) != (table2.Subquery != nil) {
+		return false
+	}
+
+	// Check if both use functions
+	if (table1.Function != nil) != (table2.Function != nil) {
+		return false
+	}
+
+	// If both use subqueries, recursively check their structure
+	if table1.Subquery != nil && table2.Subquery != nil {
+		return selectStatementsStructureSimilar(&table1.Subquery.Subquery, &table2.Subquery.Subquery)
+	}
+
+	return true
+}
+
+// selectStatementsStructureSimilar checks if two select statements have similar structure
+func selectStatementsStructureSimilar(stmt1, stmt2 *parser.SelectStatement) bool {
+	// Check UNION presence
+	if len(stmt1.Unions) != len(stmt2.Unions) {
+		return false
+	}
+
+	// Check FROM clause presence and type
+	if (stmt1.From == nil) != (stmt2.From == nil) {
+		return false
+	}
+
+	if stmt1.From != nil && stmt2.From != nil {
+		if !fromClauseStructureSimilar(&stmt1.From.Table, &stmt2.From.Table) {
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -726,6 +823,11 @@ func selectStatementsAreEqualAST(stmt1, stmt2 *parser.SelectStatement) bool {
 
 	// Compare SETTINGS clauses
 	if !settingsClausesAreEqual(stmt1.Settings, stmt2.Settings) {
+		return false
+	}
+
+	// Compare UNION clauses
+	if !unionClausesAreEqual(stmt1.Unions, stmt2.Unions) {
 		return false
 	}
 
@@ -1072,6 +1174,111 @@ func settingsClausesAreEqual(settings1, settings2 *parser.SettingsClause) bool {
 	}
 
 	return true
+}
+
+// unionClausesAreEqual compares UNION clauses
+func unionClausesAreEqual(unions1, unions2 []parser.UnionClause) bool {
+	if len(unions1) != len(unions2) {
+		return false
+	}
+	for i, union1 := range unions1 {
+		union2 := unions2[i]
+		if union1.All != union2.All || union1.Distinct != union2.Distinct {
+			return false
+		}
+		if union1.Select == nil && union2.Select == nil {
+			continue
+		}
+		if union1.Select == nil || union2.Select == nil {
+			return false
+		}
+		// Compare the SELECT clauses in the union
+		if !simpleSelectClausesAreEqual(union1.Select, union2.Select) {
+			return false
+		}
+	}
+	return true
+}
+
+// simpleSelectClausesAreEqual compares two SimpleSelectClause structures
+func simpleSelectClausesAreEqual(sel1, sel2 *parser.SimpleSelectClause) bool {
+	if sel1 == nil && sel2 == nil {
+		return true
+	}
+	if sel1 == nil || sel2 == nil {
+		return false
+	}
+
+	// Compare SELECT DISTINCT
+	if sel1.Distinct != sel2.Distinct {
+		return false
+	}
+
+	// Compare columns count
+	if len(sel1.Columns) != len(sel2.Columns) {
+		return false
+	}
+
+	// Compare FROM presence
+	if (sel1.From == nil) != (sel2.From == nil) {
+		return false
+	}
+
+	// Compare WHERE presence
+	if (sel1.Where == nil) != (sel2.Where == nil) {
+		return false
+	}
+
+	// Compare GROUP BY presence
+	if (sel1.GroupBy == nil) != (sel2.GroupBy == nil) {
+		return false
+	}
+
+	// Compare HAVING presence
+	if (sel1.Having == nil) != (sel2.Having == nil) {
+		return false
+	}
+
+	// Compare ORDER BY presence
+	if (sel1.OrderBy == nil) != (sel2.OrderBy == nil) {
+		return false
+	}
+
+	// Compare LIMIT
+	if !simpleSelectLimitClausesAreEqual(sel1.Limit, sel2.Limit) {
+		return false
+	}
+
+	// Compare SETTINGS
+	if !settingsClausesAreEqual(sel1.Settings, sel2.Settings) {
+		return false
+	}
+
+	return true
+}
+
+// simpleSelectLimitClausesAreEqual compares LIMIT clauses from SimpleSelectClause
+func simpleSelectLimitClausesAreEqual(limit1, limit2 *parser.LimitClause) bool {
+	if limit1 == nil && limit2 == nil {
+		return true
+	}
+	if limit1 == nil || limit2 == nil {
+		return false
+	}
+
+	// Compare count expressions
+	if !expressionsAreEqual(&limit1.Count, &limit2.Count) {
+		return false
+	}
+
+	// Compare offset expressions
+	if limit1.Offset == nil && limit2.Offset == nil {
+		return true
+	}
+	if limit1.Offset == nil || limit2.Offset == nil {
+		return false
+	}
+	return expressionsAreEqual(&limit1.Offset.Value, &limit2.Offset.Value)
 }
 
 // selectStatementToString converts a SelectStatement to a properly formatted string representation

--- a/pkg/schema/view.go
+++ b/pkg/schema/view.go
@@ -718,10 +718,28 @@ func selectStatementsAreEqualNormalized(stmt1, stmt2 *parser.SelectStatement) bo
 		}
 	}
 
-	// If we get here, the basic structure is similar
-	// For ClickHouse formatting tolerance, we'll be optimistic and assume they're equivalent
-	// This is a temporary measure to address the recreation issue
-	// TODO: Implement proper normalization comparison once format package has public methods
+	// Compare actual content so that MV/schema file changes are detected.
+	// Previously we only checked structure and returned true, so changes to
+	// columns, WHERE, GROUP BY, HAVING, FROM, or ORDER BY were missed.
+	if !selectColumnsAreEqual(stmt1.Columns, stmt2.Columns) {
+		return false
+	}
+	if !whereClausesAreEqual(stmt1.Where, stmt2.Where) {
+		return false
+	}
+	if !groupByClausesAreEqual(stmt1.GroupBy, stmt2.GroupBy) {
+		return false
+	}
+	if !havingClausesAreEqual(stmt1.Having, stmt2.Having) {
+		return false
+	}
+	if !fromClausesAreEqual(stmt1.From, stmt2.From) {
+		return false
+	}
+	if !selectOrderByClausesAreEqual(stmt1.OrderBy, stmt2.OrderBy) {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/schema/view_test.go
+++ b/pkg/schema/view_test.go
@@ -1,0 +1,287 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshClausesAreEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		refresh1 *parser.RefreshClause
+		refresh2 *parser.RefreshClause
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			refresh1: nil,
+			refresh2: nil,
+			expected: true,
+		},
+		{
+			name:     "first nil second not nil",
+			refresh1: nil,
+			refresh2: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			expected: false,
+		},
+		{
+			name:     "first not nil second nil",
+			refresh1: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			refresh2: nil,
+			expected: false,
+		},
+		{
+			name:     "equal EVERY clauses",
+			refresh1: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			refresh2: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			expected: true,
+		},
+		{
+			name:     "equal AFTER clauses",
+			refresh1: &parser.RefreshClause{After: true, Interval: 1, Unit: "HOUR"},
+			refresh2: &parser.RefreshClause{After: true, Interval: 1, Unit: "HOUR"},
+			expected: true,
+		},
+		{
+			name:     "different EVERY vs AFTER",
+			refresh1: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			refresh2: &parser.RefreshClause{After: true, Interval: 10, Unit: "SECONDS"},
+			expected: false,
+		},
+		{
+			name:     "different intervals",
+			refresh1: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			refresh2: &parser.RefreshClause{Every: true, Interval: 30, Unit: "SECONDS"},
+			expected: false,
+		},
+		{
+			name:     "different units",
+			refresh1: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			refresh2: &parser.RefreshClause{Every: true, Interval: 10, Unit: "MINUTES"},
+			expected: false,
+		},
+		{
+			name:     "case insensitive units",
+			refresh1: &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			refresh2: &parser.RefreshClause{Every: true, Interval: 10, Unit: "seconds"},
+			expected: true,
+		},
+		{
+			name: "equal with OFFSET",
+			refresh1: &parser.RefreshClause{
+				Every:          true,
+				Interval:       1,
+				Unit:           "DAY",
+				OffsetInterval: intPtr(6),
+				OffsetUnit:     stringPtr("HOURS"),
+			},
+			refresh2: &parser.RefreshClause{
+				Every:          true,
+				Interval:       1,
+				Unit:           "DAY",
+				OffsetInterval: intPtr(6),
+				OffsetUnit:     stringPtr("HOURS"),
+			},
+			expected: true,
+		},
+		{
+			name: "different OFFSET intervals",
+			refresh1: &parser.RefreshClause{
+				Every:          true,
+				Interval:       1,
+				Unit:           "DAY",
+				OffsetInterval: intPtr(6),
+				OffsetUnit:     stringPtr("HOURS"),
+			},
+			refresh2: &parser.RefreshClause{
+				Every:          true,
+				Interval:       1,
+				Unit:           "DAY",
+				OffsetInterval: intPtr(12),
+				OffsetUnit:     stringPtr("HOURS"),
+			},
+			expected: false,
+		},
+		{
+			name: "one has OFFSET other does not",
+			refresh1: &parser.RefreshClause{
+				Every:          true,
+				Interval:       1,
+				Unit:           "DAY",
+				OffsetInterval: intPtr(6),
+				OffsetUnit:     stringPtr("HOURS"),
+			},
+			refresh2: &parser.RefreshClause{
+				Every:    true,
+				Interval: 1,
+				Unit:     "DAY",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := refreshClausesAreEqual(tt.refresh1, tt.refresh2)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestViewStatementsAreEqual_RefreshAndAppend(t *testing.T) {
+	tests := []struct {
+		name     string
+		stmt1    *parser.CreateViewStmt
+		stmt2    *parser.CreateViewStmt
+		expected bool
+	}{
+		{
+			name: "both have same refresh and append",
+			stmt1: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+				Append:       true,
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			stmt2: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+				Append:       true,
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			expected: true,
+		},
+		{
+			name: "different refresh intervals",
+			stmt1: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+				Append:       true,
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			stmt2: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 30, Unit: "SECONDS"},
+				Append:       true,
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			expected: false,
+		},
+		{
+			name: "one has refresh other does not",
+			stmt1: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			stmt2: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			expected: false,
+		},
+		{
+			name: "different append flags",
+			stmt1: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+				Append:       true,
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			stmt2: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				Refresh:      &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+				Append:       false,
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			expected: false,
+		},
+		{
+			name: "neither has refresh or append",
+			stmt1: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			stmt2: &parser.CreateViewStmt{
+				Materialized: true,
+				Name:         "mv_test",
+				To:           &parser.ViewTableTarget{Table: stringPtr("target")},
+				AsSelect:     &parser.SelectStatement{},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := viewStatementsAreEqual(tt.stmt1, tt.stmt2)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatRefreshClause(t *testing.T) {
+	tests := []struct {
+		name     string
+		refresh  *parser.RefreshClause
+		expected string
+	}{
+		{
+			name:     "nil refresh",
+			refresh:  nil,
+			expected: "",
+		},
+		{
+			name:     "EVERY seconds",
+			refresh:  &parser.RefreshClause{Every: true, Interval: 10, Unit: "SECONDS"},
+			expected: "REFRESH EVERY 10 SECONDS",
+		},
+		{
+			name:     "AFTER hour",
+			refresh:  &parser.RefreshClause{After: true, Interval: 1, Unit: "HOUR"},
+			expected: "REFRESH AFTER 1 HOUR",
+		},
+		{
+			name: "EVERY day with OFFSET",
+			refresh: &parser.RefreshClause{
+				Every:          true,
+				Interval:       1,
+				Unit:           "DAY",
+				OffsetInterval: intPtr(6),
+				OffsetUnit:     stringPtr("HOURS"),
+			},
+			expected: "REFRESH EVERY 1 DAY OFFSET 6 HOURS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatRefreshClause(tt.refresh)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
+}


### PR DESCRIPTION
## Summary

ClickHouse normalizes certain data types when storing DDL in `system.tables.create_table_query`. This caused housekeeper to generate spurious `ALTER TABLE ... MODIFY COLUMN` statements on every `diff` because the normalized types didn't match the original schema definitions.

## Changes

### DateTime/DateTime64 Normalization
- ClickHouse normalizes `DateTime(precision, timezone)` → `DateTime64(precision)` in system tables
- Example: `DateTime(3, UTC)` becomes `DateTime64(3)`
- Added helper methods: `isDateTimeType()`, `isDateTimeCompatibleWith()`, `getDateTimePrecision()`
- Updated `SimpleType.Equal()` to handle cross-type DateTime comparisons

### Decimal Type Normalization
- ClickHouse normalizes:
  - `Decimal32(N)` → `Decimal(9, N)`
  - `Decimal64(N)` → `Decimal(18, N)` 
  - `Decimal128(N)` → `Decimal(38, N)`
- Added helper methods: `isDecimalType()`, `isDecimalCompatibleWith()`, `getDecimalPrecisionScale()`
- Updated `SimpleType.Equal()` to handle Decimal type normalization

### Nested Type Comparisons
- Extended normalization to `ParametricFunction.Equal()` for types nested inside aggregate functions:
  - `AggregateFunction(fn, DateTime(3, UTC))` vs `AggregateFunction(fn, DateTime64(3))`
  - `SimpleAggregateFunction(fn, Nullable(Decimal64(2)))` vs `SimpleAggregateFunction(fn, Nullable(Decimal(18, 2)))`

### TypeParameter String/Ident Comparison
- ClickHouse may output quoted strings (`'UTC'`) while user DDL uses unquoted identifiers (`UTC`)
- Added cross-type comparison in `TypeParameter.Equal()` to treat these as equivalent

## Test Plan
- [x] All existing parser tests pass
- [x] New test cases for DateTime vs DateTime64 comparison
- [x] New test cases for Decimal64 vs Decimal(18, N) comparison
- [x] Verified `housekeeper diff` no longer generates spurious ALTER statements