### PR TITLE
feat: preserve ClickHouse server-side macros in ON CLUSTER clauses

### DIFF
--- a/pkg/format/base.go
+++ b/pkg/format/base.go
@@ -56,10 +56,12 @@ func (d *DDLFormatter) buildDropStatement(objectType string, ifExists bool, name
 }
 
 // appendOnCluster appends ON CLUSTER clause if present.
+// Delegates to clusterName() so that macro references like '{cluster}' are emitted
+// verbatim while plain identifiers are backtick-quoted.
 func (d *DDLFormatter) appendOnCluster(parts []string, cluster *string) []string {
 	if cluster != nil {
 		parts = append(parts, d.formatter.keyword("ON CLUSTER"))
-		parts = append(parts, d.formatter.identifier(*cluster))
+		parts = append(parts, d.formatter.clusterName(*cluster))
 	}
 	return parts
 }

--- a/pkg/format/database.go
+++ b/pkg/format/database.go
@@ -40,7 +40,7 @@ func (f *Formatter) alterDatabase(w io.Writer, stmt *parser.AlterDatabaseStmt) e
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// Action
@@ -76,7 +76,7 @@ func (f *Formatter) attachDatabase(w io.Writer, stmt *parser.AttachDatabaseStmt)
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))

--- a/pkg/format/dictionary.go
+++ b/pkg/format/dictionary.go
@@ -29,7 +29,7 @@ func (f *Formatter) createDictionary(w io.Writer, stmt *parser.CreateDictionaryS
 		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 		if stmt.OnCluster != nil {
-			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		lines = append(lines, strings.Join(headerParts, " ")+" (")

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -445,6 +445,13 @@ func (f *Formatter) identifier(name string) string {
 	return utils.BacktickIdentifier(name)
 }
 
+// clusterName formats a cluster name for ON CLUSTER clauses.
+// Plain identifiers are backtick-quoted; ClickHouse macro references (e.g. '{cluster}')
+// are returned verbatim so that generated DDL is portable across clusters.
+func (f *Formatter) clusterName(name string) string {
+	return utils.FormatClusterName(name)
+}
+
 // commentable represents any statement that can have leading and trailing comments
 type commentable interface {
 	GetLeadingComments() []string

--- a/pkg/format/function.go
+++ b/pkg/format/function.go
@@ -23,7 +23,7 @@ func (f *Formatter) formatCreateFunction(w io.Writer, stmt *parser.CreateFunctio
 			if _, err := w.Write([]byte(" " + f.keyword("on") + " " + f.keyword("cluster") + " ")); err != nil {
 				return err
 			}
-			if _, err := w.Write([]byte(f.identifier(*stmt.OnCluster))); err != nil {
+			if _, err := w.Write([]byte(f.clusterName(*stmt.OnCluster))); err != nil {
 				return err
 			}
 		}
@@ -94,7 +94,7 @@ func (f *Formatter) formatDropFunction(w io.Writer, stmt *parser.DropFunctionStm
 
 		// Add ON CLUSTER if specified
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("on")+" "+f.keyword("cluster"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("on")+" "+f.keyword("cluster"), f.clusterName(*stmt.OnCluster))
 		}
 
 		if _, err := w.Write([]byte(strings.Join(parts, " "))); err != nil {

--- a/pkg/format/named_collection.go
+++ b/pkg/format/named_collection.go
@@ -30,7 +30,7 @@ func (f *Formatter) createNamedCollection(w io.Writer, stmt *parser.CreateNamedC
 	headerParts = append(headerParts, f.identifier(stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	headerParts = append(headerParts, f.keyword("AS"))
@@ -76,7 +76,7 @@ func (f *Formatter) alterNamedCollection(w io.Writer, stmt *parser.AlterNamedCol
 	headerParts = append(headerParts, f.identifier(stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	lines = append(lines, strings.Join(headerParts, " "))
@@ -105,7 +105,7 @@ func (f *Formatter) dropNamedCollection(w io.Writer, stmt *parser.DropNamedColle
 	headerParts = append(headerParts, f.identifier(stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	line := strings.Join(headerParts, " ") + ";"

--- a/pkg/format/role.go
+++ b/pkg/format/role.go
@@ -28,7 +28,7 @@ func (f *Formatter) createRole(w io.Writer, stmt *parser.CreateRoleStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// SETTINGS
@@ -59,7 +59,7 @@ func (f *Formatter) alterRole(w io.Writer, stmt *parser.AlterRoleStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// RENAME TO
@@ -164,7 +164,7 @@ func (f *Formatter) grant(w io.Writer, stmt *parser.GrantStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// ON target
@@ -213,7 +213,7 @@ func (f *Formatter) revoke(w io.Writer, stmt *parser.RevokeStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// ON target

--- a/pkg/format/testdata/on_cluster_macro.in.sql
+++ b/pkg/format/testdata/on_cluster_macro.in.sql
@@ -1,0 +1,8 @@
+-- Cluster macro references must be preserved verbatim (no backtick quoting)
+CREATE TABLE steam_market_data ON CLUSTER '{cluster}' (ts DateTime64(6), price Int64) ENGINE = ReplicatedReplacingMergeTree() ORDER BY ts;
+
+-- Plain cluster names are backtick-quoted
+CREATE TABLE logs ON CLUSTER production (ts DateTime, msg String) ENGINE = MergeTree() ORDER BY ts;
+
+-- DROP with macro cluster
+DROP TABLE IF EXISTS events ON CLUSTER '{cluster}';

--- a/pkg/format/testdata/on_cluster_macro.sql
+++ b/pkg/format/testdata/on_cluster_macro.sql
@@ -1,0 +1,21 @@
+-- Cluster macro references must be preserved verbatim (no backtick quoting)
+
+CREATE TABLE `steam_market_data` ON CLUSTER '{cluster}' (
+    `ts`    DateTime64(6),
+    `price` Int64
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY `ts`;
+
+-- Plain cluster names are backtick-quoted
+
+CREATE TABLE `logs` ON CLUSTER `production` (
+    `ts`  DateTime,
+    `msg` String
+)
+ENGINE = MergeTree()
+ORDER BY `ts`;
+
+-- DROP with macro cluster
+
+DROP TABLE `events` ON CLUSTER '{cluster}';

--- a/pkg/format/view.go
+++ b/pkg/format/view.go
@@ -33,7 +33,7 @@ func (f *Formatter) createView(w io.Writer, stmt *parser.CreateViewStmt) error {
 		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 		if stmt.OnCluster != nil {
-			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		lines = append(lines, strings.Join(headerParts, " "))

--- a/pkg/parser/database.go
+++ b/pkg/parser/database.go
@@ -11,7 +11,7 @@ type (
 		Database    string          `parser:"'DATABASE'"`
 		IfNotExists bool            `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Name        string          `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Engine      *DatabaseEngine `parser:"@@?"`
 		Comment     *string         `parser:"('COMMENT' @String)?"`
 		TrailingCommentField
@@ -36,7 +36,7 @@ type (
 		Alter     string               `parser:"'ALTER'"`
 		Database  string               `parser:"'DATABASE'"`
 		Name      string               `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string              `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string              `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Action    *AlterDatabaseAction `parser:"@@"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -56,7 +56,7 @@ type (
 		IfNotExists bool            `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Name        string          `parser:"@(Ident | BacktickIdent)"`
 		Engine      *DatabaseEngine `parser:"@@?"`
-		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -69,7 +69,7 @@ type (
 		Database    string  `parser:"'DATABASE'"`
 		IfExists    bool    `parser:"@('IF' 'EXISTS')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently bool    `parser:"@'PERMANENTLY'?"`
 		Sync        bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
@@ -84,7 +84,7 @@ type (
 		Database  string  `parser:"'DATABASE'"`
 		IfExists  bool    `parser:"@('IF' 'EXISTS')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -97,7 +97,7 @@ type (
 		Rename    string            `parser:"'RENAME'"`
 		Database  string            `parser:"'DATABASE'"`
 		Renames   []*DatabaseRename `parser:"@@ (',' @@)*"`
-		OnCluster *string           `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string           `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}

--- a/pkg/parser/database_stmt_test.go
+++ b/pkg/parser/database_stmt_test.go
@@ -16,6 +16,7 @@ func TestCreateDatabase(t *testing.T) {
 		{name: "full_options", sql: "CREATE DATABASE IF NOT EXISTS full_db ON CLUSTER production ENGINE = Atomic COMMENT 'Full featured database';"},
 		{name: "with_backticks", sql: "CREATE DATABASE `user-database` ENGINE = Atomic;"},
 		{name: "backticks_full", sql: "CREATE DATABASE IF NOT EXISTS `order-db` ON CLUSTER `prod-cluster` COMMENT 'Database with special chars';"},
+		{name: "on_cluster_macro", sql: "CREATE DATABASE mydb ON CLUSTER '{cluster}' ENGINE = Atomic;"},
 	}
 
 	runStatementTests(t, "database/create", tests)

--- a/pkg/parser/dictionary.go
+++ b/pkg/parser/dictionary.go
@@ -27,7 +27,7 @@ type (
 		IfNotExists *string             `parser:"(@'IF' 'NOT' 'EXISTS')?"`
 		Database    *string             `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name        string              `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Columns     []*DictionaryColumn `parser:"'(' @@* ')'"`
 		Clauses     []DictionaryClause  `parser:"@@*"`
 		Comment     *string             `parser:"('COMMENT' @String)?"`
@@ -159,7 +159,7 @@ type (
 		IfNotExists *string `parser:"'ATTACH' 'DICTIONARY' (@'IF' 'NOT' 'EXISTS')?"`
 		Database    *string `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -172,7 +172,7 @@ type (
 		IfExists    *string `parser:"'DETACH' 'DICTIONARY' (@'IF' 'EXISTS')?"`
 		Database    *string `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently *string `parser:"(@'PERMANENTLY')?"`
 		Sync        *string `parser:"(@'SYNC')?"`
 		TrailingCommentField
@@ -187,7 +187,7 @@ type (
 		IfExists  *string `parser:"'DROP' 'DICTIONARY' (@'IF' 'EXISTS')?"`
 		Database  *string `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      *string `parser:"(@'SYNC')?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -198,7 +198,7 @@ type (
 	RenameDictionaryStmt struct {
 		LeadingCommentField
 		Renames   []*DictionaryRename `parser:"'RENAME' 'DICTIONARY' @@ (',' @@)*"`
-		OnCluster *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}

--- a/pkg/parser/function.go
+++ b/pkg/parser/function.go
@@ -7,7 +7,7 @@ type (
 	CreateFunctionStmt struct {
 		LeadingCommentField
 		Name       string           `parser:"'CREATE' 'FUNCTION' @(Ident | BacktickIdent)"`
-		OnCluster  *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Parameters []*FunctionParam `parser:"'AS' ( '(' (@@ (',' @@)*)? ')' | @@ )"`
 		Expression *Expression      `parser:"'->' @@"`
 		TrailingCommentField
@@ -20,7 +20,7 @@ type (
 		LeadingCommentField
 		IfExists  bool    `parser:"'DROP' 'FUNCTION' @('IF' 'EXISTS')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}

--- a/pkg/parser/named_collection.go
+++ b/pkg/parser/named_collection.go
@@ -22,7 +22,7 @@ type (
 		Collection     string                      `parser:"'COLLECTION'"`
 		IfNotExists    *string                     `parser:"(@'IF' 'NOT' 'EXISTS')?"`
 		Name           string                      `parser:"@(Ident | BacktickIdent)"`
-		OnCluster      *string                     `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster      *string                     `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		As             string                      `parser:"'AS'"`
 		Parameters     []*NamedCollectionParameter `parser:"@@*"`
 		GlobalOverride *NamedCollectionOverride    `parser:"@@?"`
@@ -41,7 +41,7 @@ type (
 		Collection string                          `parser:"'COLLECTION'"`
 		IfExists   *string                         `parser:"(@'IF' 'EXISTS')?"`
 		Name       string                          `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string                         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string                         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Operations *AlterNamedCollectionOperations `parser:"@@? ';'"`
 	}
 
@@ -67,7 +67,7 @@ type (
 		Collection string  `parser:"'COLLECTION'"`
 		IfExists   *string `parser:"(@'IF' 'EXISTS')?"`
 		Name       string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Semicolon  string  `parser:"';'"`
 	}
 

--- a/pkg/parser/role.go
+++ b/pkg/parser/role.go
@@ -8,7 +8,7 @@ type (
 		OrReplace   bool          `parser:"'CREATE' (@'OR' 'REPLACE')? 'ROLE'"`
 		IfNotExists bool          `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Name        string        `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Settings    *RoleSettings `parser:"@@?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -20,7 +20,7 @@ type (
 		LeadingCommentField
 		IfExists  bool          `parser:"'ALTER' 'ROLE' @('IF' 'EXISTS')?"`
 		Name      string        `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		RenameTo  *string       `parser:"('RENAME' 'TO' @(Ident | BacktickIdent))?"`
 		Settings  *RoleSettings `parser:"@@?"`
 		TrailingCommentField
@@ -33,7 +33,7 @@ type (
 		LeadingCommentField
 		IfExists  bool     `parser:"'DROP' 'ROLE' @('IF' 'EXISTS')?"`
 		Names     []string `parser:"@(Ident | BacktickIdent) (',' @(Ident | BacktickIdent))*"`
-		OnCluster *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -65,7 +65,7 @@ type (
 	GrantStmt struct {
 		LeadingCommentField
 		Privileges  *PrivilegeList `parser:"'GRANT' @@"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		On          *GrantTarget   `parser:"('ON' @@)?"`
 		To          *GranteeList   `parser:"'TO' @@"`
 		WithGrant   bool           `parser:"@('WITH' 'GRANT' 'OPTION')?"`
@@ -82,7 +82,7 @@ type (
 		GrantOption bool           `parser:"'REVOKE' (@'GRANT' 'OPTION' 'FOR'"`
 		AdminOption bool           `parser:"| @'ADMIN' 'OPTION' 'FOR')?"`
 		Privileges  *PrivilegeList `parser:"@@"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		On          *GrantTarget   `parser:"('ON' @@)?"`
 		From        *GranteeList   `parser:"'FROM' @@"`
 		TrailingCommentField

--- a/pkg/parser/table.go
+++ b/pkg/parser/table.go
@@ -59,7 +59,7 @@ type (
 		IfNotExists       bool           `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Database          *string        `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name              string         `parser:"@(Ident | BacktickIdent)"`
-		OnCluster         *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster         *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		AsTable           *TableSource   `parser:"('AS' @@)?"`
 		Elements          []TableElement `parser:"('(' @@ (',' @@)* ')')?"`
 		PreEngineComments []string       `parser:"@(Comment | MultilineComment)*"`
@@ -245,7 +245,7 @@ type (
 		IfNotExists bool    `parser:"('IF' 'NOT' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -260,7 +260,7 @@ type (
 		IfExists    bool    `parser:"('IF' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently bool    `parser:"@'PERMANENTLY'?"`
 		Sync        bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
@@ -277,7 +277,7 @@ type (
 		IfExists  bool    `parser:"('IF' 'EXISTS')?"`
 		Database  *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -291,7 +291,7 @@ type (
 		LeadingCommentField
 		Rename    string        `parser:"'RENAME' 'TABLE'"`
 		Renames   []TableRename `parser:"@@ (',' @@)*"`
-		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -326,7 +326,7 @@ type (
 		IfExists   bool                  `parser:"@('IF' 'EXISTS')?"`
 		Database   *string               `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name       string                `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string               `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string               `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Operations []AlterTableOperation `parser:"@@ (',' @@)*"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`

--- a/pkg/parser/table_stmt_test.go
+++ b/pkg/parser/table_stmt_test.go
@@ -53,6 +53,9 @@ func TestCreateTable(t *testing.T) {
 		SETTINGS index_granularity = 8192, merge_with_ttl_timeout = 3600
 		COMMENT 'User events table';`},
 
+		// Cluster macro references ('{cluster}', '{shard}', etc.)
+		{name: "on_cluster_macro", sql: `CREATE TABLE steam_market_data ON CLUSTER '{cluster}' (ts DateTime64(6), price Int64) ENGINE = ReplicatedReplacingMergeTree() ORDER BY ts;`},
+
 		// Backticks
 		{name: "with_backticks", sql: "CREATE TABLE `user-db`.`order-table` (`user-id` UInt64, `order-id` String, `order-date` Date, `select` String, `group` LowCardinality(String)) ENGINE = MergeTree() ORDER BY (`user-id`, `order-date`);"},
 
@@ -220,6 +223,7 @@ func TestDropTable(t *testing.T) {
 		{name: "basic", sql: `DROP TABLE users;`},
 		{name: "if_exists", sql: `DROP TABLE IF EXISTS temp_table;`},
 		{name: "on_cluster", sql: `DROP TABLE measurements ON CLUSTER production;`},
+		{name: "on_cluster_macro", sql: `DROP TABLE IF EXISTS events ON CLUSTER '{cluster}';`},
 		{name: "sync", sql: `DROP TABLE user_profiles SYNC;`},
 		{name: "full_options", sql: `DROP TABLE IF EXISTS analytics.old_events ON CLUSTER production SYNC;`},
 		{name: "with_backticks", sql: "DROP TABLE IF EXISTS `analytics-db`.`user-events` ON CLUSTER `prod-cluster`;"},

--- a/pkg/parser/testdata/database/create/on_cluster_macro.sql
+++ b/pkg/parser/testdata/database/create/on_cluster_macro.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE `mydb` ON CLUSTER '{cluster}' ENGINE = Atomic;

--- a/pkg/parser/testdata/table/create/on_cluster_macro.sql
+++ b/pkg/parser/testdata/table/create/on_cluster_macro.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `steam_market_data` ON CLUSTER '{cluster}' (
+    `ts`    DateTime64(6),
+    `price` Int64
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY `ts`;

--- a/pkg/parser/testdata/table/drop/on_cluster_macro.sql
+++ b/pkg/parser/testdata/table/drop/on_cluster_macro.sql
@@ -1,0 +1,1 @@
+DROP TABLE `events` ON CLUSTER '{cluster}';

--- a/pkg/parser/testdata/view/create/on_cluster_macro.sql
+++ b/pkg/parser/testdata/view/create/on_cluster_macro.sql
@@ -1,0 +1,2 @@
+CREATE VIEW `v` ON CLUSTER '{cluster}'
+AS SELECT 1;

--- a/pkg/parser/view.go
+++ b/pkg/parser/view.go
@@ -28,7 +28,7 @@ type (
 		IfNotExists  bool             `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Database     *string          `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name         string           `parser:"@(Ident | BacktickIdent)"`
-		OnCluster    *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster    *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		To           *ViewTableTarget `parser:"('TO' @@)?"`
 		Engine       *ViewEngine      `parser:"@@?"`
 		Populate     bool             `parser:"@'POPULATE'?"`
@@ -47,7 +47,7 @@ type (
 		IfNotExists bool    `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -62,7 +62,7 @@ type (
 		IfExists    bool    `parser:"@('IF' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently bool    `parser:"@'PERMANENTLY'?"`
 		Sync        bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
@@ -79,7 +79,7 @@ type (
 		IfExists  bool    `parser:"@('IF' 'EXISTS')?"`
 		Database  *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`

--- a/pkg/parser/view_stmt_test.go
+++ b/pkg/parser/view_stmt_test.go
@@ -9,6 +9,7 @@ func TestCreateView(t *testing.T) {
 		{name: "basic", sql: `CREATE VIEW analytics.daily_summary AS SELECT date, count(*) AS total FROM events GROUP BY date;`},
 		{name: "if_not_exists", sql: `CREATE VIEW IF NOT EXISTS users_view AS SELECT id, name FROM users WHERE active = 1;`},
 		{name: "on_cluster", sql: `CREATE VIEW stats_view ON CLUSTER production AS SELECT * FROM statistics;`},
+		{name: "on_cluster_macro", sql: `CREATE VIEW v ON CLUSTER '{cluster}' AS SELECT 1;`},
 		{name: "or_replace", sql: `CREATE OR REPLACE VIEW analytics.updated_view AS SELECT id, name, updated_at FROM users ORDER BY updated_at DESC;`},
 		{name: "with_backticks", sql: "CREATE VIEW `analytics-db`.`daily-summary` AS SELECT `order-date` AS `date`, count(*) AS `total-orders` FROM `orders-table` GROUP BY `order-date`;"},
 		{name: "with_window_functions", sql: `CREATE VIEW analytics.user_rankings AS SELECT user_id, name, score, row_number() OVER (ORDER BY score DESC) AS rank, rank() OVER (PARTITION BY category ORDER BY score DESC) AS category_rank FROM user_scores ORDER BY score DESC;`},

--- a/pkg/schema/dictionary.go
+++ b/pkg/schema/dictionary.go
@@ -760,9 +760,9 @@ func buildDictionaryHeader(parts []string, stmt *parser.CreateDictionaryStmt, us
 		parts = append(parts, stmt.Name)
 	}
 
-	// ON CLUSTER
+	// ON CLUSTER — use FormatClusterName so macro refs like '{cluster}' are emitted verbatim
 	if stmt.OnCluster != nil {
-		parts = append(parts, "ON CLUSTER", *stmt.OnCluster)
+		parts = append(parts, "ON CLUSTER", utils.FormatClusterName(*stmt.OnCluster))
 	}
 
 	return parts

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 
+	A "github.com/IBM/fp-go/v2/array"
+	O "github.com/IBM/fp-go/v2/option"
 	"github.com/pseudomuto/housekeeper/pkg/compare"
 	"github.com/pseudomuto/housekeeper/pkg/consts"
 	"github.com/pseudomuto/housekeeper/pkg/parser"
@@ -194,6 +196,20 @@ func compareTables(current, target *parser.SQL) ([]*TableDiff, error) {
 	targetTables, err := extractTablesFromSQL(target)
 	if err != nil {
 		return nil, err
+	}
+
+	// Normalise the cluster name in all current (live-DB) tables to match the
+	// target schema's cluster convention. ClickHouse expands macros like
+	// '{cluster}' to their concrete values (e.g. 'default') when reporting
+	// SHOW CREATE TABLE, so the current state always holds the concrete name.
+	// Without this step, ALTER/DROP/RENAME migrations would hard-code the
+	// cluster name instead of preserving the portable macro syntax.
+	if sc := inferSchemaCluster(targetTables); sc != "" {
+		for _, t := range currentTables {
+			if t.Cluster != "" {
+				t.Cluster = sc
+			}
+		}
 	}
 
 	// Pre-allocate diffs slice with estimated capacity
@@ -556,9 +572,36 @@ func findRenamedTable(targetTable *TableInfo, currentTables, targetTables map[st
 	return ""
 }
 
-// tablesEqual compares two tables for equality
-func tablesEqual(a, b *TableInfo) bool {
-	return a.Equal(b)
+// inferSchemaCluster returns the authoritative cluster name from the target schema.
+// Priority:
+//  1. Any server macro (e.g. '{cluster}') — portable across clusters.
+//  2. Unanimous plain name — all clustered tables agree on the same value.
+//  3. "" — mixed names or no clustered tables; conservative, avoids incorrect rewrites.
+//
+// The result is applied to live-DB tables before diff generation so that ALTER / DROP /
+// RENAME migrations emit the same cluster syntax as the desired schema instead of the
+// concrete name ClickHouse reports after macro expansion.
+func inferSchemaCluster(tables map[string]*TableInfo) string {
+	clusters := make([]string, 0, len(tables))
+	for _, t := range tables {
+		if t.Cluster != "" {
+			clusters = append(clusters, t.Cluster)
+		}
+	}
+	return O.MonadGetOrElse(
+		O.MonadAlt(
+			A.FindFirst(utils.IsClickHouseMacro)(clusters),
+			func() O.Option[string] {
+				return O.MonadChain(A.Head(clusters), func(first string) O.Option[string] {
+					if A.Any(func(c string) bool { return c != first })(clusters) {
+						return O.None[string]()
+					}
+					return O.Some(first)
+				})
+			},
+		),
+		func() string { return "" },
+	)
 }
 
 // tablesEqualIgnoringName compares two tables for equality ignoring name and database
@@ -683,11 +726,13 @@ func formatQualifiedTableName(database, name string) string {
 	return name
 }
 
-// writeOnClusterClause writes an ON CLUSTER clause if cluster is specified
+// writeOnClusterClause writes an ON CLUSTER clause if cluster is specified.
+// Uses FormatClusterName so that macro references (e.g. '{cluster}') are emitted verbatim
+// and plain names are backtick-quoted for safety.
 func writeOnClusterClause(sql *strings.Builder, cluster string) {
 	if cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(cluster)
+		sql.WriteString(utils.FormatClusterName(cluster))
 	}
 }
 
@@ -913,7 +958,7 @@ func handleTableExists(tableName string, currentTable, targetTable *TableInfo) (
 	// For comparison purposes, flatten the target table to match ClickHouse's internal representation
 	// Current table is already flattened by ClickHouse, but target table may have Nested syntax
 	flattenedTargetTable := FlattenNestedColumns(targetTable)
-	if tablesEqual(currentTable, flattenedTargetTable) {
+	if currentTable.Equal(flattenedTargetTable) {
 		return nil, nil
 	}
 

--- a/pkg/schema/table_test.go
+++ b/pkg/schema/table_test.go
@@ -108,6 +108,152 @@ func TestTableInfoEqual(t *testing.T) {
 	require.False(t, result, "Tables with different ReplicatedMergeTree parameters should not be equal")
 }
 
+func TestInferSchemaCluster(t *testing.T) {
+	cases := []struct {
+		name     string
+		tables   map[string]*TableInfo
+		expected string
+	}{
+		{
+			name: "macro cluster is authoritative",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "'{cluster}'"},
+				"sales":  {Cluster: "'{cluster}'"},
+			},
+			expected: "'{cluster}'",
+		},
+		{
+			name: "macro wins over plain names in the same map",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "default"},
+				"sales":  {Cluster: "'{cluster}'"},
+			},
+			expected: "'{cluster}'",
+		},
+		{
+			name: "unanimous plain name is returned",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "default"},
+				"sales":  {Cluster: "default"},
+			},
+			expected: "default",
+		},
+		{
+			name: "mixed plain names — no normalisation",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "cluster-a"},
+				"sales":  {Cluster: "cluster-b"},
+			},
+			expected: "",
+		},
+		{
+			name: "no clustered tables — no normalisation",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: ""},
+			},
+			expected: "",
+		},
+		{
+			name:     "empty map",
+			tables:   map[string]*TableInfo{},
+			expected: "",
+		},
+		{
+			name: "shard macro is also accepted",
+			tables: map[string]*TableInfo{
+				"metrics": {Cluster: "'{shard}'"},
+			},
+			expected: "'{shard}'",
+		},
+		{
+			name: "plain-quoted string without braces is NOT a macro",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "'plain-string'"},
+			},
+			expected: "'plain-string'", // treated as unanimous plain name
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inferSchemaCluster(tc.tables)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestCompareTables_ClusterNormalisation verifies that ALTER/DROP/RENAME
+// migrations use the target schema's cluster macro ('{cluster}') rather than
+// the concrete cluster name that ClickHouse reports after macro expansion.
+func TestCompareTables_ClusterNormalisation(t *testing.T) {
+	// current = live DB state after applying migrations; ClickHouse has expanded
+	// '{cluster}' → 'default' in SHOW CREATE TABLE output.
+	current, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER default (
+			id UInt64, name String
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	// target = desired schema with the portable macro syntax.
+	target, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER '{cluster}' (
+			id UInt64, name String, ts DateTime
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	diffs, err := compareTables(current, target)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+
+	// The ALTER TABLE migration must use the macro, not the concrete name.
+	require.Contains(t, diffs[0].UpSQL, "'{cluster}'",
+		"ALTER TABLE UpSQL must use the macro cluster syntax")
+	require.NotContains(t, diffs[0].UpSQL, "`default`",
+		"ALTER TABLE UpSQL must not hard-code the concrete cluster name")
+}
+
+// TestCompareTables_DropClusterNormalisation verifies that DROP TABLE
+// migrations generated for orphaned tables also use the target schema's cluster
+// macro rather than the concrete cluster name from the live DB.
+func TestCompareTables_DropClusterNormalisation(t *testing.T) {
+	// current contains a table that no longer exists in the desired schema.
+	current, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER default (
+			id UInt64
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+		CREATE TABLE orphan ON CLUSTER default (
+			id UInt64
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	// target keeps only 'events', using the portable macro.
+	target, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER '{cluster}' (
+			id UInt64
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	diffs, err := compareTables(current, target)
+	require.NoError(t, err)
+
+	var dropDiff *TableDiff
+	for _, d := range diffs {
+		if d.Type == string(TableDiffDrop) {
+			dropDiff = d
+			break
+		}
+	}
+	require.NotNil(t, dropDiff, "expected a DROP diff for orphan table")
+	require.Contains(t, dropDiff.UpSQL, "'{cluster}'",
+		"DROP TABLE UpSQL must use the macro cluster syntax")
+	require.NotContains(t, dropDiff.UpSQL, "`default`",
+		"DROP TABLE UpSQL must not hard-code the concrete cluster name")
+}
+
 // Helper function to create string pointers
 func stringPtr(s string) *string {
 	return &s

--- a/pkg/utils/identifier.go
+++ b/pkg/utils/identifier.go
@@ -1,6 +1,17 @@
 package utils
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+// chMacroRe matches ClickHouse server-side macro references as stored by the
+// participle lexer. The lexer emits String tokens with their surrounding single
+// quotes intact, so '{cluster}' is stored as the Go string "'{cluster}'".
+//
+// Pattern: opening quote, opening brace, a valid ClickHouse identifier
+// ([A-Za-z_][A-Za-z0-9_]*), closing brace, closing quote.
+var chMacroRe = regexp.MustCompile(`^'\{[A-Za-z_][A-Za-z0-9_]*\}'$`)
 
 // BacktickIdentifier adds backticks around an identifier, handling nested identifiers.
 // It properly handles database.table.column style identifiers by backticking each part.
@@ -93,6 +104,73 @@ func BacktickQualifiedName(database *string, name string) string {
 //   - "" -> false
 func IsBackticked(s string) bool {
 	return len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' && !strings.Contains(s[1:len(s)-1], "`")
+}
+
+// IsClusterMacro reports whether a cluster name is a ClickHouse server macro reference.
+//
+// ClickHouse macros use single-quoted braces in ON CLUSTER clauses, e.g. '{cluster}',
+// '{shard}'. These are expanded at query execution time from the server's macros config
+// (<macros><cluster>…</cluster></macros>). They must be preserved verbatim in DDL so that
+// migrations are portable across clusters with different names.
+//
+// The parser stores the raw lexer token value for String tokens, which includes the
+// surrounding single quotes, so '{cluster}' is stored as the Go string "'{cluster}'".
+//
+// Examples:
+//
+//	IsClusterMacro("'{cluster}'") → true
+//	IsClusterMacro("'{shard}'")   → true
+//	IsClusterMacro("default")     → false
+//	IsClusterMacro("")            → false
+func IsClusterMacro(s string) bool {
+	return len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\''
+}
+
+// IsClickHouseMacro reports whether s is a ClickHouse server macro reference
+// of the form '{identifier}' (single-quoted curly-brace expression).
+//
+// This is stricter than IsClusterMacro: it requires the inner content to be a
+// valid identifier wrapped in curly braces, matching the ClickHouse <macros>
+// config substitution syntax. Use this when you need to distinguish a genuine
+// server macro (suitable for cross-cluster portability) from an arbitrary
+// single-quoted cluster name.
+//
+// Examples:
+//
+//	IsClickHouseMacro("'{cluster}'")      → true
+//	IsClickHouseMacro("'{shard}'")        → true
+//	IsClickHouseMacro("'{replica}'")      → true
+//	IsClickHouseMacro("'plain-string'")   → false  (no braces)
+//	IsClickHouseMacro("default")          → false  (not quoted)
+//	IsClickHouseMacro("")                 → false
+func IsClickHouseMacro(s string) bool {
+	return chMacroRe.MatchString(s)
+}
+
+// FormatClusterName formats a cluster name for use in SQL DDL output.
+//
+// This is the single, canonical place where the macro-vs-identifier distinction is
+// handled for ON CLUSTER clauses. It is used by the formatter, SQLBuilder, and the
+// schema DDL generators so that macro syntax is preserved end-to-end.
+//
+// - Macro references (e.g. "'{cluster}'") are returned as-is — the single quotes are
+//   part of the ClickHouse syntax and must not be wrapped in backticks.
+// - Plain identifiers (e.g. "default", "my-cluster") are backtick-quoted for safety.
+//
+// Examples:
+//
+//	FormatClusterName("'{cluster}'") → "'{cluster}'"
+//	FormatClusterName("default")     → "`default`"
+//	FormatClusterName("")            → ""
+func FormatClusterName(name string) string {
+	switch {
+	case name == "":
+		return ""
+	case IsClusterMacro(name):
+		return name
+	default:
+		return BacktickIdentifier(name)
+	}
 }
 
 // StripBackticks removes backticks from an identifier if present.

--- a/pkg/utils/identifier_test.go
+++ b/pkg/utils/identifier_test.go
@@ -274,3 +274,87 @@ func TestStripBackticks(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+func TestIsClusterMacro(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		// ClickHouse server macro references — single-quoted braces
+		{"'{cluster}'", true},
+		{"'{shard}'", true},
+		{"'{replica}'", true},
+		// Any single-quoted value is treated as a macro by the parser convention
+		{"'any-quoted-string'", true},
+		// Plain identifiers must NOT be treated as macros
+		{"default", false},
+		{"my-cluster", false},
+		{"`default`", false},
+		// Edge cases
+		{"", false},
+		{"'", false},  // not a valid single-quoted string (no closing quote)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, utils.IsClusterMacro(tc.input))
+		})
+	}
+}
+
+func TestIsClickHouseMacro(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		// Proper ClickHouse server macro syntax: '{identifier}'
+		{"'{cluster}'", true},
+		{"'{shard}'", true},
+		{"'{replica}'", true},
+		{"'{my_macro}'", true},
+		// Single-quoted strings without braces are NOT server macros
+		{"'any-quoted-string'", false},
+		{"'default'", false},
+		// Plain identifiers are not macros
+		{"default", false},
+		{"my-cluster", false},
+		{"`default`", false},
+		// Malformed macro patterns
+		{"'{}'", false},           // empty identifier
+		{"'{123bad}'", false},     // identifier starts with digit
+		{"'{cluster'", false},     // missing closing brace
+		{"'{cluster}x'", false},   // trailing content after brace
+		// Edge cases
+		{"", false},
+		{"'", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, utils.IsClickHouseMacro(tc.input))
+		})
+	}
+}
+
+func TestFormatClusterName(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// Macro references must be returned verbatim (no extra quoting)
+		{"'{cluster}'", "'{cluster}'"},
+		{"'{shard}'", "'{shard}'"},
+		// Plain identifiers must be backtick-quoted
+		{"default", "`default`"},
+		{"my-cluster", "`my-cluster`"},
+		{"prod", "`prod`"},
+		// Empty string — nothing to format
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, utils.FormatClusterName(tc.input))
+		})
+	}
+}

--- a/pkg/utils/sqlbuilder.go
+++ b/pkg/utils/sqlbuilder.go
@@ -138,13 +138,17 @@ func (b *SQLBuilder) QualifiedName(database *string, name string) *SQLBuilder {
 
 // OnCluster adds an ON CLUSTER clause if cluster is not empty.
 //
+// Plain cluster names are backtick-quoted; ClickHouse macro references (e.g. '{cluster}')
+// are emitted verbatim so that generated migrations are portable across clusters.
+//
 // Example:
 //
-//	builder.OnCluster("production")  // ON CLUSTER `production`
-//	builder.OnCluster("")            // (nothing added)
+//	builder.OnCluster("production")   // ON CLUSTER `production`
+//	builder.OnCluster("'{cluster}'")  // ON CLUSTER '{cluster}'
+//	builder.OnCluster("")             // (nothing added)
 func (b *SQLBuilder) OnCluster(cluster string) *SQLBuilder {
 	if cluster != "" {
-		b.parts = append(b.parts, "ON", "CLUSTER", BacktickIdentifier(cluster))
+		b.parts = append(b.parts, "ON", "CLUSTER", FormatClusterName(cluster))
 	}
 	return b
 }


### PR DESCRIPTION
ClickHouse allow the usage of server-side macros as the cluster name, e.g. `ON CLUSTER '{cluster}'`, where `{cluster}` is resolved at query time from the server's `<macros>` config. The formatter was backtick-quoting the whole value, turning it into a literal identifier:

```sql
-- when we write
ON CLUSTER '{cluster}'

-- housekeeper was emitting
ON CLUSTER `{cluster}`
```

The second form fails at runtime because no cluster named `{cluster}` exists — it's supposed to be a macro, not a name.

This adds `IsClickHouseMacro` and `FormatClusterName` to `pkg/utils`, and wires them through all DDL parsers and formatters (table, view, database, dictionary, function, named_collection, role). Plain cluster names like `ON CLUSTER my_cluster` continue to be quoted as before.