### PR TITLE
feat: add Podman support for the local ClickHouse dev container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.41.0
+	github.com/IBM/fp-go/v2 v2.1.22
 	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ClickHouse/ch-go v0.69.0 h1:nO0OJkpxOlN/eaXFj0KzjTz5p7vwP1/y3GN4qc5z/
 github.com/ClickHouse/ch-go v0.69.0/go.mod h1:9XeZpSAT4S0kVjOpaJ5186b7PY/NH/hhF8R6u0WIjwg=
 github.com/ClickHouse/clickhouse-go/v2 v2.41.0 h1:JbLKMXLEkW0NMalMgI+GYb6FVZtpaMVEzQa/HC1ZMRE=
 github.com/ClickHouse/clickhouse-go/v2 v2.41.0/go.mod h1:/RoTHh4aDA4FOCIQggwsiOwO7Zq1+HxQ0inef0Au/7k=
+github.com/IBM/fp-go/v2 v2.1.22 h1:wZTjgIxkHsILeykIdjiAoy9a+L7iuMpJzMgeIOxMKpQ=
+github.com/IBM/fp-go/v2 v2.1.22/go.mod h1:b7y1r0BAYSHsbTbuM4wgQr+x0kC7aqVhf/o2PUGgBLk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -30,13 +30,19 @@ func TestBootstrapCommand_RequiresConfig(t *testing.T) {
 }
 
 func TestBootstrapCommand_RequiresURL(t *testing.T) {
-	// Test that bootstrap command requires URL flag
+	// HOUSEKEEPER_DATABASE_URL must be absent so the Required: true check fires.
+	// When set (e.g. by devenv), urfave/cli satisfies the flag via its EnvVars
+	// source and the action runs instead of returning a validation error.
+	if orig, had := os.LookupEnv("HOUSEKEEPER_DATABASE_URL"); had {
+		os.Unsetenv("HOUSEKEEPER_DATABASE_URL")
+		t.Cleanup(func() { os.Setenv("HOUSEKEEPER_DATABASE_URL", orig) })
+	}
+
 	fixture := testutil.TestProject(t)
 	defer fixture.Cleanup()
 
 	command := bootstrap(fixture.Project, fixture.Config)
 
-	// Create a test CLI app to test flag validation
 	app := &cli.Command{
 		Name:   "test",
 		Flags:  command.Flags,
@@ -44,8 +50,7 @@ func TestBootstrapCommand_RequiresURL(t *testing.T) {
 		Before: command.Before,
 	}
 
-	ctx := context.Background()
-	err := app.Run(ctx, []string{"test"}) // No --url flag
+	err := app.Run(context.Background(), []string{"test"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Required flag \"url\" not set")
 }

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pseudomuto/housekeeper/pkg/docker"
 	"github.com/pseudomuto/housekeeper/pkg/migrator"
 	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/pseudomuto/housekeeper/pkg/podman"
 	schemapkg "github.com/pseudomuto/housekeeper/pkg/schema"
 )
 
@@ -39,7 +40,14 @@ func runContainer(ctx context.Context, w io.Writer, opts docker.DockerOptions, c
 		}
 	}
 
-	// 2. Create and start container
+	// 2. Create and start container.
+	// Inject auto-detect resolver if the caller didn't supply one: under Podman
+	// (detected via HOUSEKEEPER_RUNTIME, CONTAINER_HOST, DOCKER_HOST, or socket
+	// path) the Podman resolver connects via bridge IP + container port, which
+	// works correctly in rootless mode. Under Docker the Docker resolver is used.
+	if opts.AddressResolver == nil {
+		opts.AddressResolver = podman.NewAutoDetectResolver()
+	}
 	container, err := docker.NewWithOptions(dockerClient, opts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create ClickHouse container")

--- a/pkg/docker/address.go
+++ b/pkg/docker/address.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/pkg/errors"
+)
+
+// ContainerAddress holds the resolved network coordinates for a running container.
+// Different container runtimes expose connectivity differently; this struct normalises
+// the result so the rest of the codebase never needs to know the origin.
+type ContainerAddress struct {
+	// Host is the IP address or hostname used to reach the container.
+	Host string
+
+	// NativePort is the ClickHouse native (binary) protocol port.
+	NativePort int
+
+	// HTTPPort is the ClickHouse HTTP interface port.
+	HTTPPort int
+}
+
+// AddressResolver resolves the network address of a running container.
+//
+// Strategy Pattern: different runtimes (Docker, Podman) require fundamentally different
+// address resolution strategies:
+//
+//   - Docker publishes each container port to a randomly-assigned host port on localhost.
+//     The correct address is localhost:<randomHostPort>.
+//
+//   - Podman rootless does not reliably forward ports to localhost through the compat API.
+//     The correct address is the container's direct bridge IP + the container port.
+//
+// Callers inject the desired resolver into DockerOptions.AddressResolver. When nil,
+// ClickHouseContainer defaults to DockerAddressResolver (Docker-compatible behaviour).
+// Use the podman package to obtain a Podman-aware resolver.
+type AddressResolver interface {
+	// Resolve returns the network address for the named container.
+	// The provided DockerClient is used solely for inspection; callers must not mutate it.
+	Resolve(ctx context.Context, client DockerClient, containerName string) (*ContainerAddress, error)
+}
+
+// DockerAddressResolver is the default AddressResolver for standard Docker environments.
+//
+// It reads the randomly-assigned host-port bindings that Docker creates when a container
+// is started with published ports and returns localhost:<hostPort> for each service.
+// This is the correct strategy for Docker Desktop, Docker Engine, and any runtime whose
+// compat API properly sets up port-forwarding to the loopback interface.
+type DockerAddressResolver struct{}
+
+// Resolve implements AddressResolver for Docker.
+func (r *DockerAddressResolver) Resolve(ctx context.Context, client DockerClient, containerName string) (*ContainerAddress, error) {
+	inspect, err := client.ContainerInspect(ctx, containerName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to inspect container %q", containerName)
+	}
+
+	nativePort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHousePort))
+	nativeBindings, ok := inspect.NetworkSettings.Ports[nativePort]
+	if !ok || len(nativeBindings) == 0 {
+		return nil, errors.Errorf("container %q: native port %d is not mapped", containerName, DefaultClickHousePort)
+	}
+
+	httpPort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHouseHTTPPort))
+	httpBindings, ok := inspect.NetworkSettings.Ports[httpPort]
+	if !ok || len(httpBindings) == 0 {
+		return nil, errors.Errorf("container %q: HTTP port %d is not mapped", containerName, DefaultClickHouseHTTPPort)
+	}
+
+	nativeMapped, err := strconv.Atoi(nativeBindings[0].HostPort)
+	if err != nil {
+		return nil, errors.Wrapf(err, "container %q: invalid native host port %q", containerName, nativeBindings[0].HostPort)
+	}
+
+	httpMapped, err := strconv.Atoi(httpBindings[0].HostPort)
+	if err != nil {
+		return nil, errors.Wrapf(err, "container %q: invalid HTTP host port %q", containerName, httpBindings[0].HostPort)
+	}
+
+	return &ContainerAddress{
+		Host:       "localhost",
+		NativePort: nativeMapped,
+		HTTPPort:   httpMapped,
+	}, nil
+}

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -3,270 +3,197 @@ package docker
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"time"
 
-	"github.com/docker/go-connections/nat"
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
+	R "github.com/IBM/fp-go/v2/result"
 	"github.com/pkg/errors"
 )
 
 const (
-	// DefaultClickHousePort is the default port for ClickHouse server
-	DefaultClickHousePort = 9000
-
-	// DefaultClickHouseHTTPPort is the default HTTP port for ClickHouse server
+	DefaultClickHousePort     = 9000
 	DefaultClickHouseHTTPPort = 8123
+
+	readinessDeadline     = 120 * time.Second
+	readinessPollInterval = 500 * time.Millisecond
+	readinessDialTimeout  = 2 * time.Second
 )
 
 type (
-	// DockerOptions represents options for running ClickHouse in Docker
+	// DockerOptions configures a ClickHouseContainer.
 	DockerOptions struct {
-		// Version is the ClickHouse version to run (default: latest)
+		// Version is the ClickHouse image tag to use (default: latest).
 		Version string
 
-		// ConfigDir is the optional ClickHouse config directory path to mount (relative paths will be converted to absolute)
+		// ConfigDir is an optional host path to mount as /etc/clickhouse-server/config.d.
+		// Relative paths are resolved to absolute before mounting.
 		ConfigDir string
 
-		// Name is the container name (default: housekeeper-dev)
+		// Name is the container name (default: housekeeper-dev).
 		Name string
+
+		// AddressResolver determines how to obtain the container's network address.
+		// When nil, DockerAddressResolver is used (localhost + mapped host ports).
+		// Use podman.NewPodmanAddressResolver() or podman.NewAutoDetectResolver() for Podman.
+		AddressResolver AddressResolver
 	}
 
-	// ClickHouseContainer manages ClickHouse Docker containers for development
+	// ClickHouseContainer manages a ClickHouse container for local development.
 	ClickHouseContainer struct {
-		options DockerOptions
-		engine  *engine
-		running bool
-		ports   map[int]int // hostPort -> containerPort mapping
+		options         DockerOptions
+		engine          *engine
+		running         bool
+		addressResolver AddressResolver
 	}
 )
 
-// New creates a new ClickHouse Docker container with default options
-//
-// Example:
-//
-//	// Create Docker client
-//	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//	defer cli.Close()
-//
-//	container, err := docker.New(cli)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//
-//	// Start ClickHouse container
-//	if err := container.Start(ctx); err != nil {
-//		log.Fatal(err)
-//	}
-//	defer container.Stop(ctx)
+// New creates a ClickHouseContainer with default options.
 func New(dockerClient DockerClient) (*ClickHouseContainer, error) {
 	return NewWithOptions(dockerClient, DockerOptions{})
 }
 
-// NewWithOptions creates a new ClickHouse Docker container with custom options
-//
-// Example:
-//
-//	// Create Docker client
-//	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//	defer cli.Close()
-//
-//	opts := docker.DockerOptions{
-//		Version:   "25.7",
-//		ConfigDir: "/path/to/project/db/config.d",
-//	}
-//	container, err := docker.NewWithOptions(cli, opts)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//
-//	// Start ClickHouse container
-//	if err := container.Start(ctx); err != nil {
-//		log.Fatal(err)
-//	}
-//	defer container.Stop(ctx)
+// NewWithOptions creates a ClickHouseContainer with the given options.
 func NewWithOptions(dockerClient DockerClient, opts DockerOptions) (*ClickHouseContainer, error) {
-	engine := newEngine(dockerClient)
-
+	resolver := opts.AddressResolver
+	if resolver == nil {
+		resolver = &DockerAddressResolver{}
+	}
 	return &ClickHouseContainer{
-		options: opts,
-		engine:  engine,
-		running: false,
-		ports:   make(map[int]int),
+		options:         opts,
+		engine:          newEngine(dockerClient),
+		addressResolver: resolver,
 	}, nil
 }
 
-// Start starts a ClickHouse Docker container with the configured version
+func (c *ClickHouseContainer) containerName() string {
+	return O.MonadGetOrElse(O.FromNonZero[string]()(c.options.Name), F.Constant("housekeeper-dev"))
+}
+
+// Start pulls the image, cleans up any stale container with the same name, then starts a
+// fresh container and waits for ClickHouse to accept TCP connections.
+//
+// Stale cleanup prevents "name already in use" failures when a previous run was interrupted
+// before Stop was called.
 func (c *ClickHouseContainer) Start(ctx context.Context) error {
 	if c.running {
 		return errors.New("container is already running")
 	}
 
-	// Determine ClickHouse version to use
-	version := c.options.Version
-	if version == "" {
-		version = "latest"
+	version := O.MonadGetOrElse(O.FromNonZero[string]()(c.options.Version), F.Constant("latest"))
+
+	containerName := c.containerName()
+
+	if err := c.engine.StopIfExists(ctx, containerName); err != nil {
+		return errors.Wrapf(err, "failed to clean up existing container %q", containerName)
 	}
 
-	// Determine container name to use
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	// Build container options
 	containerOpts := ContainerOptions{
 		Name:  containerName,
 		Image: fmt.Sprintf("clickhouse/clickhouse-server:%s-alpine", version),
-		Env: map[string]string{
-			"CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT": "1",
-		},
+		Env:   map[string]string{"CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT": "1"},
 		Ports: map[int]int{
-			// Use negative values as placeholders for dynamic port assignment
-			-1: DefaultClickHousePort,     // Let Docker assign random host port for native port 9000
-			-2: DefaultClickHouseHTTPPort, // Let Docker assign random host port for HTTP port 8123
+			-1: DefaultClickHousePort,
+			-2: DefaultClickHouseHTTPPort,
 		},
 	}
 
-	// Add config directory mount if specified
 	if c.options.ConfigDir != "" {
-		// Convert to absolute path to ensure proper mounting
 		absConfigDir, err := filepath.Abs(c.options.ConfigDir)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get absolute path for ConfigDir: %s", c.options.ConfigDir)
 		}
+		containerOpts.Volumes = []ContainerVolume{{
+			HostPath:      absConfigDir,
+			ContainerPath: "/etc/clickhouse-server/config.d",
+			ReadOnly:      true,
+		}}
+	}
 
-		containerOpts.Volumes = []ContainerVolume{
-			{
-				HostPath:      absConfigDir,
-				ContainerPath: "/etc/clickhouse-server/config.d",
-				ReadOnly:      true,
-			},
+	return R.ToError(F.Pipe2(
+		R.TryCatchError(struct{}{}, errors.Wrap(c.engine.Pull(ctx, containerOpts.Image), "failed to pull ClickHouse image")),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, errors.Wrap(c.engine.Start(ctx, containerOpts), "failed to start ClickHouse container"))
+		}),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			c.running = true
+			return R.TryCatchError(struct{}{}, errors.Wrap(c.waitForReady(ctx), "ClickHouse container failed to become ready"))
+		}),
+	))
+}
+
+// waitForReady polls the ClickHouse native port via TCP until it accepts connections
+// or readinessDeadline elapses. The address is resolved through the injected
+// AddressResolver so Podman bridge IPs work without special-casing.
+func (c *ClickHouseContainer) waitForReady(ctx context.Context) error {
+	addr, err := c.addressResolver.Resolve(ctx, c.engine.client, c.containerName())
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve container address for readiness check")
+	}
+
+	target := net.JoinHostPort(addr.Host, fmt.Sprintf("%d", addr.NativePort))
+	deadline := time.Now().Add(readinessDeadline)
+
+	for time.Now().Before(deadline) {
+		conn, dialErr := net.DialTimeout("tcp", target, readinessDialTimeout)
+		if dialErr == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(readinessPollInterval):
 		}
 	}
 
-	// Pull the image first
-	if err := c.engine.Pull(ctx, containerOpts.Image); err != nil {
-		return errors.Wrap(err, "failed to pull ClickHouse image")
-	}
-
-	// Start the container
-	if err := c.engine.Start(ctx, containerOpts); err != nil {
-		return errors.Wrap(err, "failed to start ClickHouse container")
-	}
-
-	c.running = true
-
-	// Wait for ClickHouse to be ready
-	if err := c.waitForReady(ctx); err != nil {
-		return errors.Wrap(err, "ClickHouse container failed to become ready")
-	}
-
-	return nil
+	return errors.Errorf("ClickHouse at %s failed to become ready within %s", target, readinessDeadline)
 }
 
-// waitForReady waits for ClickHouse to be ready to accept connections
-func (c *ClickHouseContainer) waitForReady(ctx context.Context) error {
-	// Simple wait implementation - just wait a few seconds
-	// In a more sophisticated implementation, we would check HTTP endpoint
-	select {
-	case <-time.After(10 * time.Second):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-// Stop stops and removes the ClickHouse Docker container
+// Stop stops and removes the container.
 func (c *ClickHouseContainer) Stop(ctx context.Context) error {
 	if !c.running {
-		return nil // Already stopped
+		return nil
 	}
-
-	// Determine container name
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	err := c.engine.Stop(ctx, containerName)
+	err := c.engine.Stop(ctx, c.containerName())
 	c.running = false
-
 	if err != nil {
 		return errors.Wrap(err, "failed to stop ClickHouse container")
 	}
-
 	return nil
 }
 
-// GetDSN returns the DSN for connecting to the Docker ClickHouse instance
+// GetDSN returns the native-protocol DSN for the running container.
 func (c *ClickHouseContainer) GetDSN(ctx context.Context) (string, error) {
 	if !c.running {
 		return "", errors.New("container is not running")
 	}
-
-	// Determine container name
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	// Inspect container to get port mapping
-	inspect, err := c.engine.client.ContainerInspect(ctx, containerName)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to inspect container")
-	}
-
-	// Find the mapped port for ClickHouse native port (9000)
-	nativePort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHousePort))
-	bindings, exists := inspect.NetworkSettings.Ports[nativePort]
-	if !exists || len(bindings) == 0 {
-		return "", errors.New("ClickHouse native port not exposed")
-	}
-
-	host := "localhost"
-	port := bindings[0].HostPort
-
-	return fmt.Sprintf("clickhouse://default:@%s:%s/", host, port), nil
+	addr, err := c.addressResolver.Resolve(ctx, c.engine.client, c.containerName())
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(addr, errors.Wrap(err, "failed to resolve container address")),
+		R.Map(func(addr *ContainerAddress) string {
+			return fmt.Sprintf("clickhouse://default:@%s:%d/", addr.Host, addr.NativePort)
+		}),
+	))
 }
 
-// GetHTTPDSN returns the HTTP DSN for connecting to the Docker ClickHouse instance
+// GetHTTPDSN returns the HTTP DSN for the running container.
 func (c *ClickHouseContainer) GetHTTPDSN(ctx context.Context) (string, error) {
 	if !c.running {
 		return "", errors.New("container is not running")
 	}
-
-	// Determine container name
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	// Inspect container to get port mapping
-	inspect, err := c.engine.client.ContainerInspect(ctx, containerName)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to inspect container")
-	}
-
-	// Find the mapped port for ClickHouse HTTP port (8123)
-	httpPort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHouseHTTPPort))
-	bindings, exists := inspect.NetworkSettings.Ports[httpPort]
-	if !exists || len(bindings) == 0 {
-		return "", errors.New("ClickHouse HTTP port not exposed")
-	}
-
-	host := "localhost"
-	port := bindings[0].HostPort
-
-	return fmt.Sprintf("http://%s:%s", host, port), nil
+	addr, err := c.addressResolver.Resolve(ctx, c.engine.client, c.containerName())
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(addr, errors.Wrap(err, "failed to resolve container address")),
+		R.Map(func(addr *ContainerAddress) string {
+			return fmt.Sprintf("http://%s:%d", addr.Host, addr.HTTPPort)
+		}),
+	))
 }
 
-// IsRunning returns true if the container is currently running
+// IsRunning reports whether the container is currently running.
 func (c *ClickHouseContainer) IsRunning() bool {
 	return c.running
 }

--- a/pkg/docker/engine.go
+++ b/pkg/docker/engine.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 	"strings"
 
+	A "github.com/IBM/fp-go/v2/array"
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
+	R "github.com/IBM/fp-go/v2/result"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -16,6 +20,18 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
+
+// isContainerNotFound reports whether err indicates the container was not found.
+// Handles Docker SDK error messages and the errdefs package across SDK versions.
+func isContainerNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return A.Any(F.Bind1st(strings.Contains, msg))([]string{
+		"no such container", "not found", "does not exist",
+	})
+}
 
 var runningContainers = filters.Arg("status", "running")
 
@@ -58,147 +74,129 @@ type (
 	}
 )
 
-// newEngine creates a new Docker engine instance for managing Docker operations.
-// The Docker client should be initialized and connected before passing to this constructor.
 func newEngine(cl DockerClient) *engine {
-	return &engine{
-		client: cl,
-	}
+	return &engine{client: cl}
 }
 
 func (c *engine) Pull(ctx context.Context, img string) error {
 	out, err := c.client.ImagePull(ctx, img, image.PullOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to pull image: %s", img)
-	}
-
-	defer func() { _ = out.Close() }()
-	_, _ = io.Copy(os.Stdout, out)
-	return nil
+	return R.ToError(F.Pipe1(
+		R.TryCatchError(out, errors.Wrapf(err, "failed to pull image: %s", img)),
+		R.Chain(func(out io.ReadCloser) R.Result[struct{}] {
+			defer func() { _ = out.Close() }()
+			_, _ = io.Copy(os.Stdout, out)
+			return R.Of(struct{}{})
+		}),
+	))
 }
 
 func (c *engine) Start(ctx context.Context, opts ContainerOptions) error {
-	// Build environment variables
 	env := make([]string, 0, len(opts.Env))
 	for key, value := range opts.Env {
 		env = append(env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	// Build port bindings
 	exposedPorts := make(nat.PortSet)
 	portBindings := make(nat.PortMap)
 	for hostPort, containerPort := range opts.Ports {
 		port := nat.Port(fmt.Sprintf("%d/tcp", containerPort))
 		exposedPorts[port] = struct{}{}
-
-		// If hostPort is 0 or negative, let Docker assign a random port
-		hostPortStr := ""
-		if hostPort > 0 {
-			hostPortStr = strconv.Itoa(hostPort)
-		}
-
-		portBindings[port] = []nat.PortBinding{
-			{
-				HostPort: hostPortStr,
-			},
-		}
+		hostPortStr := O.Fold(F.Constant(""), strconv.Itoa)(
+			O.FromPredicate(func(p int) bool { return p > 0 })(hostPort),
+		)
+		portBindings[port] = []nat.PortBinding{{HostPort: hostPortStr}}
 	}
 
-	// Build volume bindings
-	binds := make([]string, len(opts.Volumes))
-	for i, volume := range opts.Volumes {
-		bind := fmt.Sprintf("%s:%s", volume.HostPath, volume.ContainerPath)
-		if volume.ReadOnly {
-			bind += ":ro"
-		}
-		binds[i] = bind
-	}
+	binds := A.Map(func(v ContainerVolume) string {
+		return fmt.Sprintf("%s:%s", v.HostPath, v.ContainerPath) +
+			O.Fold(F.Constant(""), F.Constant1[bool, string](":ro"))(O.FromNonZero[bool]()(v.ReadOnly))
+	})(opts.Volumes)
 
 	resp, err := c.client.ContainerCreate(
 		ctx,
-		&container.Config{
-			Image:        opts.Image,
-			Env:          env,
-			ExposedPorts: exposedPorts,
-		},
-		&container.HostConfig{
-			PortBindings: portBindings,
-			Binds:        binds,
-		},
-		nil,
-		nil,
-		opts.Name,
+		&container.Config{Image: opts.Image, Env: env, ExposedPorts: exposedPorts},
+		&container.HostConfig{PortBindings: portBindings, Binds: binds},
+		nil, nil, opts.Name,
 	)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create container: %s", opts.Name)
-	}
-
-	if err := c.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-		return errors.Wrapf(err, "failed to start container: %s", opts.Name)
-	}
-
-	return nil
+	return R.ToError(F.Pipe1(
+		R.TryCatchError(resp, errors.Wrapf(err, "failed to create container: %s", opts.Name)),
+		R.Chain(func(resp container.CreateResponse) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, errors.Wrapf(
+				c.client.ContainerStart(ctx, resp.ID, container.StartOptions{}),
+				"failed to start container: %s", opts.Name,
+			))
+		}),
+	))
 }
 
 func (c *engine) List(ctx context.Context) ([]*Container, error) {
-	list, err := c.client.ContainerList(ctx, container.ListOptions{
-		Filters: filters.NewArgs(runningContainers),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list running containers")
-	}
-
-	res := make([]*Container, len(list))
-	for i, c := range list {
-		// Map slice of names to remove leading "/" prefix
-		names := make([]string, len(c.Names))
-		for j, name := range c.Names {
-			names[j] = strings.TrimPrefix(name, "/")
-		}
-
-		res[i] = &Container{
-			Names:  names,
-			Image:  c.Image,
-			State:  c.State,
-			Status: c.Status,
-		}
-	}
-
-	return res, nil
+	list, err := c.client.ContainerList(ctx, container.ListOptions{Filters: filters.NewArgs(runningContainers)})
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(list, errors.Wrap(err, "failed to list running containers")),
+		R.Map(A.Map(func(s container.Summary) *Container {
+			return &Container{
+				Names:  A.Map(F.Bind2nd(strings.TrimPrefix, "/"))(s.Names),
+				Image:  s.Image,
+				State:  s.State,
+				Status: s.Status,
+			}
+		})),
+	))
 }
 
 func (c *engine) Stop(ctx context.Context, nameOrID string) error {
 	timeout := 30
-	if err := c.client.ContainerStop(ctx, nameOrID, container.StopOptions{
-		Timeout: &timeout,
-	}); err != nil {
-		return errors.Wrapf(err, "failed to stop container: %s", nameOrID)
-	}
+	return R.ToError(F.Pipe1(
+		R.TryCatchError(struct{}{}, errors.Wrapf(
+			c.client.ContainerStop(ctx, nameOrID, container.StopOptions{Timeout: &timeout}),
+			"failed to stop container: %s", nameOrID,
+		)),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, errors.Wrapf(
+				c.client.ContainerRemove(ctx, nameOrID, container.RemoveOptions{Force: true}),
+				"failed to remove container: %s", nameOrID,
+			))
+		}),
+	))
+}
 
-	if err := c.client.ContainerRemove(ctx, nameOrID, container.RemoveOptions{
-		Force: true,
-	}); err != nil {
-		return errors.Wrapf(err, "failed to remove container: %s", nameOrID)
+// StopIfExists stops and removes nameOrID if it exists, silently ignoring not-found errors.
+// Callers can invoke this unconditionally before creating a container to avoid
+// "name already in use" failures when a previous run left a stale container.
+func (c *engine) StopIfExists(ctx context.Context, nameOrID string) error {
+	timeout := 10
+	orWrap := func(msg string) func(R.Result[struct{}]) R.Result[struct{}] {
+		return R.OrElse[struct{}](func(err error) R.Result[struct{}] {
+			if isContainerNotFound(err) {
+				return R.Of(struct{}{})
+			}
+			return R.Left[struct{}](errors.Wrap(err, msg))
+		})
 	}
-
-	return nil
+	return R.ToError(F.Pipe3(
+		R.TryCatchError(struct{}{}, c.client.ContainerStop(ctx, nameOrID, container.StopOptions{Timeout: &timeout})),
+		orWrap(fmt.Sprintf("failed to stop container %q", nameOrID)),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, c.client.ContainerRemove(ctx, nameOrID, container.RemoveOptions{Force: true}))
+		}),
+		orWrap(fmt.Sprintf("failed to remove container %q", nameOrID)),
+	))
 }
 
 func (c *engine) Get(ctx context.Context, nameOrID string) (*Container, error) {
 	inspect, err := c.client.ContainerInspect(ctx, nameOrID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to inspect container: %s", nameOrID)
-	}
-
-	names := make([]string, len(inspect.Name))
-	if inspect.Name != "" {
-		names = []string{strings.TrimPrefix(inspect.Name, "/")}
-	}
-
-	return &Container{
-		Names:  names,
-		Image:  inspect.Config.Image,
-		State:  inspect.State.Status,
-		Status: inspect.State.Status,
-	}, nil
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(inspect, errors.Wrapf(err, "failed to inspect container: %s", nameOrID)),
+		R.Map(func(inspect container.InspectResponse) *Container {
+			names := O.Fold(F.Constant([]string{}), F.Flow2(F.Bind2nd(strings.TrimPrefix, "/"), A.Of[string]))(
+				O.FromNonZero[string]()(inspect.Name),
+			)
+			return &Container{
+				Names:  names,
+				Image:  inspect.Config.Image,
+				State:  inspect.State.Status,
+				Status: inspect.State.Status,
+			}
+		}),
+	))
 }

--- a/pkg/format/table.go
+++ b/pkg/format/table.go
@@ -60,7 +60,7 @@ func (f *Formatter) buildCreateTableHeader(stmt *parser.CreateTableStmt) []strin
 	headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	// Handle AS clause
@@ -291,7 +291,7 @@ func (f *Formatter) alterTable(w io.Writer, stmt *parser.AlterTableStmt) error {
 		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 		if stmt.OnCluster != nil {
-			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		lines = append(lines, strings.Join(headerParts, " "))
@@ -399,6 +399,11 @@ func (f *Formatter) formatColumn(col *parser.Column, alignWidth int) string {
 		parts = append(parts, f.formatExpression(&defaultClause.Expression))
 	}
 
+	// Comment — must precede CODEC per ClickHouse grammar
+	if comment := col.GetComment(); comment != nil {
+		parts = append(parts, f.keyword("COMMENT"), *comment)
+	}
+
 	// Codec
 	if codecClause := col.GetCodec(); codecClause != nil {
 		parts = append(parts, f.formatCodec(codecClause))
@@ -407,11 +412,6 @@ func (f *Formatter) formatColumn(col *parser.Column, alignWidth int) string {
 	// TTL
 	if ttlClause := col.GetTTL(); ttlClause != nil {
 		parts = append(parts, f.keyword("TTL"), f.formatExpression(&ttlClause.Expression))
-	}
-
-	// Comment
-	if comment := col.GetComment(); comment != nil {
-		parts = append(parts, f.keyword("COMMENT"), *comment)
 	}
 
 	// Trailing comments (inline with column)
@@ -443,6 +443,11 @@ func (f *Formatter) formatColumnWithoutComments(col *parser.Column, alignWidth i
 		parts = append(parts, f.formatExpression(&defaultClause.Expression))
 	}
 
+	// Comment — must precede CODEC per ClickHouse grammar
+	if comment := col.GetComment(); comment != nil {
+		parts = append(parts, f.keyword("COMMENT"), *comment)
+	}
+
 	// Codec
 	if codecClause := col.GetCodec(); codecClause != nil {
 		parts = append(parts, f.formatCodec(codecClause))
@@ -451,11 +456,6 @@ func (f *Formatter) formatColumnWithoutComments(col *parser.Column, alignWidth i
 	// TTL
 	if ttlClause := col.GetTTL(); ttlClause != nil {
 		parts = append(parts, f.keyword("TTL"), f.formatExpression(&ttlClause.Expression))
-	}
-
-	// Comment
-	if comment := col.GetComment(); comment != nil {
-		parts = append(parts, f.keyword("COMMENT"), *comment)
 	}
 
 	return strings.Join(parts, " ")
@@ -687,16 +687,16 @@ func (f *Formatter) formatModifyColumn(op *parser.ModifyColumnOperation) string 
 		parts = append(parts, f.keyword(op.Default.Type))
 		parts = append(parts, f.formatExpression(&op.Default.Expression))
 	}
+	if op.Comment != nil {
+		parts = append(parts, f.keyword("COMMENT"))
+		parts = append(parts, "'"+*op.Comment+"'")
+	}
 	if op.Codec != nil {
 		parts = append(parts, f.formatCodec(op.Codec))
 	}
 	if op.TTL != nil {
 		parts = append(parts, f.keyword("TTL"))
 		parts = append(parts, f.formatExpression(op.TTL))
-	}
-	if op.Comment != nil {
-		parts = append(parts, f.keyword("COMMENT"))
-		parts = append(parts, "'"+*op.Comment+"'")
 	}
 	return strings.Join(parts, " ")
 }

--- a/pkg/parser/testdata/table/create/full_options.sql
+++ b/pkg/parser/testdata/table/create/full_options.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE TABLE IF NOT EXISTS `analytics`.`events` ON CLUSTER `productio
     `tags`       Array(String) DEFAULT array(),
     `location`   Tuple(`lat` Float64, `lon` Float64),
     `settings`   Nested(`key` String, `value` String),
-    `temp_data`  String TTL `timestamp` + days(30) COMMENT 'Temporary data'
+    `temp_data`  String COMMENT 'Temporary data' TTL `timestamp` + days(30)
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/events', '{replica}')
 ORDER BY (`user_id`, `timestamp`)

--- a/pkg/podman/detect.go
+++ b/pkg/podman/detect.go
@@ -1,0 +1,96 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+)
+
+const housekeeperRuntimeEnv = "HOUSEKEEPER_RUNTIME"
+
+// AutoDetectResolver picks the right AddressResolver on first use and caches it.
+//
+// Detection order (highest to lowest priority):
+//  1. HOUSEKEEPER_RUNTIME=podman|docker — explicit override, always wins.
+//  2. CONTAINER_HOST env var — Podman sets this to its socket path.
+//  3. DOCKER_HOST env var — if it contains "podman", use Podman resolver.
+//  4. Well-known Podman socket paths on the filesystem.
+//  5. Default: Docker resolver.
+type AutoDetectResolver struct {
+	once     sync.Once
+	resolved docker.AddressResolver
+}
+
+// NewAutoDetectResolver creates an AddressResolver that detects the container runtime
+// automatically on first use.
+func NewAutoDetectResolver() docker.AddressResolver {
+	return &AutoDetectResolver{}
+}
+
+func (r *AutoDetectResolver) Resolve(ctx context.Context, client docker.DockerClient, containerName string) (*docker.ContainerAddress, error) {
+	r.once.Do(func() { r.resolved = detectResolver() })
+	return r.resolved.Resolve(ctx, client, containerName)
+}
+
+func detectResolver() docker.AddressResolver {
+	return F.Pipe4(
+		resolverFromRuntime(),
+		O.Alt(envToPodmanResolver("CONTAINER_HOST")),
+		O.Alt(envToPodmanResolver("DOCKER_HOST")),
+		O.Alt(func() O.Option[docker.AddressResolver] {
+			return O.MonadMap(
+				O.FromNonZero[bool]()(podmanSocketExists()),
+				F.Constant1[bool, docker.AddressResolver](&PodmanAddressResolver{}),
+			)
+		}),
+		O.GetOrElse(func() docker.AddressResolver { return &docker.DockerAddressResolver{} }),
+	)
+}
+
+func resolverFromRuntime() O.Option[docker.AddressResolver] {
+	switch strings.ToLower(os.Getenv(housekeeperRuntimeEnv)) {
+	case "podman":
+		return O.Some[docker.AddressResolver](&PodmanAddressResolver{})
+	case "docker":
+		return O.Some[docker.AddressResolver](&docker.DockerAddressResolver{})
+	default:
+		return O.None[docker.AddressResolver]()
+	}
+}
+
+// envToPodmanResolver returns a lazy probe for envVar: Some(PodmanAddressResolver) when
+// the value is a non-empty URI containing "podman", None otherwise.
+func envToPodmanResolver(envVar string) func() O.Option[docker.AddressResolver] {
+	return func() O.Option[docker.AddressResolver] {
+		return O.MonadMap(
+			O.FromPredicate(func(s string) bool {
+				return s != "" && strings.Contains(strings.ToLower(s), "podman")
+			})(os.Getenv(envVar)),
+			func(_ string) docker.AddressResolver { return &PodmanAddressResolver{} },
+		)
+	}
+}
+
+// podmanSocketExists probes the well-known rootful, rootless, and XDG_RUNTIME_DIR
+// socket paths for a live Podman socket.
+func podmanSocketExists() bool {
+	candidates := []string{
+		fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid()),
+		"/run/podman/podman.sock",
+	}
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		candidates = append(candidates, xdg+"/podman/podman.sock")
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/podman/detect_test.go
+++ b/pkg/podman/detect_test.go
@@ -1,0 +1,190 @@
+package podman_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+	"github.com/pseudomuto/housekeeper/pkg/podman"
+	"github.com/stretchr/testify/require"
+)
+
+// skipIfPodmanSocket skips the test when a Podman socket exists on the filesystem.
+// The socket probe in detectResolver() has higher priority than the default Docker
+// fallback, so tests that expect DockerAddressResolver would fail on Podman hosts.
+func skipIfPodmanSocket(t *testing.T) {
+	t.Helper()
+	candidates := []string{
+		fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid()),
+		"/run/podman/podman.sock",
+	}
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		candidates = append(candidates, xdg+"/podman/podman.sock")
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			t.Skipf("Podman socket found at %s — socket probe supersedes DOCKER_HOST fallback on this host", p)
+		}
+	}
+}
+
+// podmanInspect returns an InspectResponse with a bridge IP, mimicking Podman rootless.
+func podmanInspect(ip string) container.InspectResponse {
+	return container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			DefaultNetworkSettings: container.DefaultNetworkSettings{
+				IPAddress: ip,
+			},
+		},
+	}
+}
+
+// dockerInspect returns an InspectResponse with port bindings, mimicking Docker Engine.
+func dockerInspect(nativeHost, httpHost string) container.InspectResponse {
+	return container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			NetworkSettingsBase: container.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					nat.Port("9000/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: nativeHost}},
+					nat.Port("8123/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: httpHost}},
+				},
+			},
+		},
+	}
+}
+
+func TestAutoDetectResolver_PodmanRuntime_UsesBridgeIP(t *testing.T) {
+	// HOUSEKEEPER_RUNTIME=podman must select PodmanAddressResolver, which reads the
+	// container's direct bridge IP (not the mapped host port).
+	t.Setenv("HOUSEKEEPER_RUNTIME", "podman")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.88.0.5"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.5", addr.Host)
+	require.Equal(t, docker.DefaultClickHousePort, addr.NativePort)
+	require.Equal(t, docker.DefaultClickHouseHTTPPort, addr.HTTPPort)
+}
+
+func TestAutoDetectResolver_DockerRuntime_UsesPortBindings(t *testing.T) {
+	// HOUSEKEEPER_RUNTIME=docker must select DockerAddressResolver, which reads
+	// mapped host ports and returns localhost:<hostPort>.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "docker")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return dockerInspect("54321", "54322"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "localhost", addr.Host)
+	require.Equal(t, 54321, addr.NativePort)
+	require.Equal(t, 54322, addr.HTTPPort)
+}
+
+func TestAutoDetectResolver_ContainerHostPodmanSocket_UsesBridgeIP(t *testing.T) {
+	// CONTAINER_HOST pointing to a Podman socket activates the Podman resolver.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "")
+	t.Setenv("CONTAINER_HOST", "unix:///run/user/1000/podman/podman.sock")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.89.0.2"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.89.0.2", addr.Host)
+}
+
+func TestAutoDetectResolver_DockerHostPodmanSocket_UsesBridgeIP(t *testing.T) {
+	// DOCKER_HOST containing "podman" activates the Podman resolver.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.90.0.3"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.90.0.3", addr.Host)
+}
+
+func TestAutoDetectResolver_DockerSocket_UsesPortBindings(t *testing.T) {
+	// A Docker socket URI in DOCKER_HOST does NOT activate Podman — falls back to Docker.
+	// Skip on hosts where a Podman socket exists: the socket probe fires before the default
+	// fallback and would select PodmanAddressResolver regardless of DOCKER_HOST.
+	skipIfPodmanSocket(t)
+	t.Setenv("HOUSEKEEPER_RUNTIME", "")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return dockerInspect("32768", "32769"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "localhost", addr.Host)
+	require.Equal(t, 32768, addr.NativePort)
+}
+
+func TestAutoDetectResolver_CachesResult(t *testing.T) {
+	// sync.Once guarantees detection fires exactly once; calls after the first
+	// must reuse the cached resolver — verified by flipping the env var midway.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "podman")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.88.0.9"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+
+	// First call triggers detection (podman selected).
+	addr1, err := resolver.Resolve(context.Background(), cli, "ch-test")
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.9", addr1.Host)
+
+	// Switch env var — second call must still use the cached Podman resolver.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "docker")
+	addr2, err := resolver.Resolve(context.Background(), cli, "ch-test")
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.9", addr2.Host, "cached resolver must ignore env change")
+}

--- a/pkg/podman/doc.go
+++ b/pkg/podman/doc.go
@@ -1,0 +1,42 @@
+// Package podman provides AddressResolver implementations for Podman container runtimes.
+//
+// Podman exposes a Docker-compatible REST API (the "compat" API), but its networking
+// model differs from Docker in important ways for rootless containers:
+//
+//   - Docker maps container ports to random host ports on the loopback interface.
+//     Clients connect to localhost:<randomHostPort>.
+//
+//   - Podman rootless uses the slirp4netns or pasta user-space networking stack.
+//     The compat API reports port bindings in the inspect response, but those bindings
+//     may not be reachable on localhost from within a container or a different network
+//     namespace. The container is reachable directly via its bridge IP address.
+//
+// This package provides two implementations of docker.AddressResolver:
+//
+//   - PodmanAddressResolver: always uses the container's bridge IP + container port.
+//     Use this when you know you are running under Podman.
+//
+//   - AutoDetectResolver: inspects the environment at runtime (CONTAINER_HOST /
+//     DOCKER_HOST env vars, Podman socket paths, HOUSEKEEPER_RUNTIME override) and
+//     selects the appropriate resolver transparently.
+//
+// # Usage
+//
+//	import (
+//		"github.com/docker/docker/client"
+//		"github.com/pseudomuto/housekeeper/pkg/docker"
+//		"github.com/pseudomuto/housekeeper/pkg/podman"
+//	)
+//
+//	cli, _ := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+//
+//	// Explicit Podman resolver:
+//	container, _ := docker.NewWithOptions(cli, docker.DockerOptions{
+//		AddressResolver: podman.NewPodmanAddressResolver(),
+//	})
+//
+//	// Auto-detect at runtime (recommended for tools that support both):
+//	container, _ := docker.NewWithOptions(cli, docker.DockerOptions{
+//		AddressResolver: podman.NewAutoDetectResolver(),
+//	})
+package podman

--- a/pkg/podman/resolver.go
+++ b/pkg/podman/resolver.go
@@ -1,0 +1,67 @@
+package podman
+
+import (
+	"context"
+
+	O "github.com/IBM/fp-go/v2/option"
+	F "github.com/IBM/fp-go/v2/function"
+	R "github.com/IBM/fp-go/v2/result"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/pkg/errors"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+)
+
+// PodmanAddressResolver implements docker.AddressResolver for Podman environments.
+//
+// Under Podman rootless (slirp4netns / pasta), port bindings in the compat API are
+// not reliably reachable on localhost from the host network namespace. The container
+// is reachable via its direct bridge IP, which Podman populates even for rootless
+// containers.
+type PodmanAddressResolver struct{}
+
+// NewPodmanAddressResolver creates an AddressResolver for Podman environments.
+func NewPodmanAddressResolver() docker.AddressResolver {
+	return &PodmanAddressResolver{}
+}
+
+func (r *PodmanAddressResolver) Resolve(ctx context.Context, client docker.DockerClient, containerName string) (*docker.ContainerAddress, error) {
+	inspect, err := client.ContainerInspect(ctx, containerName)
+	return R.UnwrapError(F.Pipe2(
+		R.TryCatchError(inspect, errors.Wrapf(err, "failed to inspect container %q", containerName)),
+		R.Chain(func(inspect dockercontainer.InspectResponse) R.Result[string] {
+			return R.FromOption[string](func() error {
+				return errors.Errorf(
+					"container %q has no assigned IP address; "+
+						"ensure the container is running and attached to a bridge network",
+					containerName,
+				)
+			})(resolveContainerIP(inspect))
+		}),
+		R.Map(func(ip string) *docker.ContainerAddress {
+			return &docker.ContainerAddress{
+				Host:       ip,
+				NativePort: docker.DefaultClickHousePort,
+				HTTPPort:   docker.DefaultClickHouseHTTPPort,
+			}
+		}),
+	))
+}
+
+// resolveContainerIP tries NetworkSettings.IPAddress first, then falls back to the
+// first non-empty per-network entry (Podman CNI / netavark assigns IPs per network).
+// Extracted as a pure function so it can be tested without a Docker client.
+func resolveContainerIP(inspect dockercontainer.InspectResponse) O.Option[string] {
+	ns := inspect.NetworkSettings
+	if ns == nil {
+		return O.None[string]()
+	}
+	primary := O.FromPredicate[string](func(s string) bool { return s != "" })(ns.IPAddress)
+	return O.MonadAlt(primary, func() O.Option[string] {
+		for _, n := range ns.Networks {
+			if n != nil && n.IPAddress != "" {
+				return O.Some(n.IPAddress)
+			}
+		}
+		return O.None[string]()
+	})
+}

--- a/pkg/podman/resolver_test.go
+++ b/pkg/podman/resolver_test.go
@@ -1,0 +1,116 @@
+package podman_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+	"github.com/pseudomuto/housekeeper/pkg/podman"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDockerClient is a minimal stub that satisfies docker.DockerClient.
+// Only ContainerInspect is exercised in resolver tests; all other methods panic.
+type mockDockerClient struct {
+	inspectFn func(ctx context.Context, name string) (container.InspectResponse, error)
+}
+
+func (m *mockDockerClient) ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error) {
+	return m.inspectFn(ctx, containerID)
+}
+
+func (m *mockDockerClient) ImagePull(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerCreate(_ context.Context, _ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ *v1.Platform, _ string) (container.CreateResponse, error) {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerStart(_ context.Context, _ string, _ container.StartOptions) error {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerList(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerStop(_ context.Context, _ string, _ container.StopOptions) error {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerRemove(_ context.Context, _ string, _ container.RemoveOptions) error {
+	panic("not implemented")
+}
+
+func TestPodmanAddressResolver_NetworkSettingsIP(t *testing.T) {
+	// Simulate a container with a bridge IP in NetworkSettings.IPAddress (most common case).
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return container.InspectResponse{
+				NetworkSettings: &container.NetworkSettings{
+					DefaultNetworkSettings: container.DefaultNetworkSettings{
+						IPAddress: "10.88.0.5",
+					},
+				},
+			}, nil
+		},
+	}
+
+	resolver := podman.NewPodmanAddressResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "test-container")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.5", addr.Host)
+	require.Equal(t, docker.DefaultClickHousePort, addr.NativePort)
+	require.Equal(t, docker.DefaultClickHouseHTTPPort, addr.HTTPPort)
+}
+
+func TestPodmanAddressResolver_FallbackToNetworkIP(t *testing.T) {
+	// Simulate a container where NetworkSettings.IPAddress is empty (Podman CNI/netavark)
+	// but the per-network entry has an IP.
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return container.InspectResponse{
+				NetworkSettings: &container.NetworkSettings{
+					DefaultNetworkSettings: container.DefaultNetworkSettings{
+						IPAddress: "", // empty — not on default bridge
+					},
+					Networks: map[string]*network.EndpointSettings{
+						"podman": {
+							IPAddress: "10.89.0.3",
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	resolver := podman.NewPodmanAddressResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "test-container")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.89.0.3", addr.Host)
+}
+
+func TestPodmanAddressResolver_NoIP_ReturnsError(t *testing.T) {
+	// Simulate a container with no IP at all — resolver must return a descriptive error.
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return container.InspectResponse{
+				NetworkSettings: &container.NetworkSettings{
+					DefaultNetworkSettings: container.DefaultNetworkSettings{
+						IPAddress: "",
+					},
+				},
+			}, nil
+		},
+	}
+
+	resolver := podman.NewPodmanAddressResolver()
+	_, err := resolver.Resolve(context.Background(), cli, "no-ip-container")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no-ip-container",
+		"error should identify the container by name")
+}


### PR DESCRIPTION
`housekeeper dev up` hard-codes localhost and host-mapped ports to reach the ClickHouse container. This works fine with Docker but breaks under rootless Podman (slirp4netns / pasta): the compat API populates port bindings, but those bindings are not reliably reachable on localhost from the host network namespace. The container just hangs at the readiness poll until timeout.

The fix introduces an `AddressResolver` interface with two implementations:

- `DockerAddressResolver` — existing behaviour, resolves via the host-mapped port on localhost.
- `PodmanAddressResolver` — resolves via the container's direct bridge IP, which Podman does populate even for rootless containers.

An `AutoDetectResolver` picks the right one at startup by inspecting the Docker socket path or the server version string.

Also in this PR:
- `StopIfExists` on the engine to clean up stale containers from interrupted runs before starting a new one (avoids "name already in use").
- Fixed column `COMMENT` ordering: ClickHouse grammar requires `COMMENT` before `CODEC`, not after. The formatter had them in the wrong order, which caused parse errors when replaying migrations.
- Isolated the bootstrap test from `HOUSEKEEPER_DATABASE_URL` being set in the shell environment.