### PR TITLE
feat: accept a directory as the schema entrypoint

### DIFF
--- a/pkg/schema/compile.go
+++ b/pkg/schema/compile.go
@@ -1,65 +1,92 @@
 package schema
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	A "github.com/IBM/fp-go/v2/array"
+	F "github.com/IBM/fp-go/v2/function"
+	IOE "github.com/IBM/fp-go/v2/ioeither"
+	file "github.com/IBM/fp-go/v2/ioeither/file"
+	R "github.com/IBM/fp-go/v2/result"
 )
 
-// Compile recursively compiles a schema file and its imports. It processes import directives (lines
-// starting with "-- housekeeper:import") and includes the referenced files' contents in the output.
-// Import paths are resolved relative to the current file's directory.
+var readDir = IOE.Eitherize1(os.ReadDir)
+
+// Compile recursively compiles a schema entrypoint and writes the result to w.
 //
-// Example:
+// The entrypoint may be:
+//   - A single .sql file, optionally containing -- housekeeper:import directives
+//   - A directory, in which case all *.sql files are compiled in alphabetical order
 //
-//	var buf bytes.Buffer
-//	err := schema.Compile("db/main.sql", &buf)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
+// Import paths inside a file are resolved relative to that file's directory:
 //
-//	// The compiled schema is now in buf
-//	compiledSQL := buf.String()
-//
-//	// Parse the compiled schema
-//	sql, err := parser.ParseString(compiledSQL)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
+//	-- housekeeper:import tables/users.sql
 func Compile(path string, w io.Writer) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read file %s", path)
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "-- housekeeper:import") {
-			parts := strings.Split(line, " ")
-			importPath := parts[len(parts)-1]
-
-			// Resolve import path relative to current file's directory
-			if !filepath.IsAbs(importPath) {
-				dir := filepath.Dir(path)
-				importPath = filepath.Join(dir, importPath)
+	return R.ToError(F.Pipe1(
+		file.Stat(path)(),
+		R.Chain(func(info os.FileInfo) R.Result[struct{}] {
+			if info.IsDir() {
+				return R.TryCatchError(struct{}{}, compileDir(path, w))
 			}
+			return R.TryCatchError(struct{}{}, compileFile(path, w))
+		}),
+	))
+}
 
-			if err := Compile(importPath, w); err != nil {
-				return err
-			}
+// compileDir compiles all *.sql files in dir in alphabetical order.
+// Sub-directories are ignored; use -- housekeeper:import for explicit cross-directory includes.
+func compileDir(dir string, w io.Writer) error {
+	return R.ToError(F.Pipe1(
+		readDir(dir)(),
+		R.Chain(func(entries []os.DirEntry) R.Result[struct{}] {
+			sqlFiles := A.Filter(func(e os.DirEntry) bool {
+				return !e.IsDir() && strings.HasSuffix(e.Name(), ".sql")
+			})(entries)
+			return F.Pipe1(
+				R.TraverseArray(func(e os.DirEntry) R.Result[struct{}] {
+					return R.TryCatchError(struct{}{}, compileFile(filepath.Join(dir, e.Name()), w))
+				})(sqlFiles),
+				R.Map(F.Constant1[[]struct{}, struct{}](struct{}{})),
+			)
+		}),
+	))
+}
 
-			continue
+// compileFile reads path, processes -- housekeeper:import directives recursively,
+// and writes all non-directive lines to w.
+func compileFile(path string, w io.Writer) error {
+	return R.ToError(F.Pipe2(
+		file.ReadAll(file.Open(path))(),
+		R.Map(func(b []byte) []string {
+			return strings.Split(strings.TrimRight(string(b), "\r\n"), "\n")
+		}),
+		R.Chain(func(lines []string) R.Result[struct{}] {
+			return F.Pipe1(
+				R.TraverseArray(processLine(path, w))(lines),
+				R.Map(F.Constant1[[]struct{}, struct{}](struct{}{})),
+			)
+		}),
+	))
+}
+
+// processLine returns a function that either emits line to w (for regular SQL lines) or
+// recursively compiles the referenced file (for -- housekeeper:import directives).
+// Import paths are resolved relative to the directory containing path.
+func processLine(path string, w io.Writer) func(string) R.Result[struct{}] {
+	return func(line string) R.Result[struct{}] {
+		if !strings.HasPrefix(line, "-- housekeeper:import") {
+			fmt.Fprintln(w, line)
+			return R.Of(struct{}{})
 		}
-
-		fmt.Fprintln(w, line)
+		parts := strings.Split(line, " ")
+		importPath := parts[len(parts)-1]
+		if !filepath.IsAbs(importPath) {
+			importPath = filepath.Join(filepath.Dir(path), importPath)
+		}
+		return R.TryCatchError(struct{}{}, Compile(importPath, w))
 	}
-
-	return errors.Wrapf(scanner.Err(), "failed scanning %s", path)
 }

--- a/pkg/schema/compile_test.go
+++ b/pkg/schema/compile_test.go
@@ -138,7 +138,7 @@ CREATE TABLE test_db.users (id UInt64) ENGINE = MergeTree() ORDER BY id;`
 		var buf bytes.Buffer
 		err := schema.Compile("non-existent-file.sql", &buf)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to read file")
+		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("returns error for non-existent import", func(t *testing.T) {
@@ -155,7 +155,7 @@ CREATE TABLE test_db.users (id UInt64) ENGINE = MergeTree() ORDER BY id;`
 		var buf bytes.Buffer
 		err = schema.Compile(schemaFile, &buf)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to read file")
+		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("handles absolute import paths", func(t *testing.T) {
@@ -181,6 +181,41 @@ CREATE TABLE test_db.users (id UInt64) ENGINE = MergeTree() ORDER BY id;`
 		compiled := buf.String()
 		require.Contains(t, compiled, "CREATE DATABASE test_db")
 		require.Contains(t, compiled, "CREATE TABLE test_db.imported_table")
+	})
+
+	t.Run("compiles directory entrypoint in alphabetical order", func(t *testing.T) {
+		schemaDir := t.TempDir()
+
+		err := os.WriteFile(filepath.Join(schemaDir, "02_tables.sql"), []byte(
+			"CREATE TABLE app.users (id UInt64) ENGINE = MergeTree() ORDER BY id;",
+		), consts.ModeFile)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(schemaDir, "01_databases.sql"), []byte(
+			"CREATE DATABASE app ENGINE = Atomic;",
+		), consts.ModeFile)
+		require.NoError(t, err)
+
+		// Non-.sql files should be ignored
+		err = os.WriteFile(filepath.Join(schemaDir, "README.md"), []byte("docs"), consts.ModeFile)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = schema.Compile(schemaDir, &buf)
+		require.NoError(t, err)
+
+		compiled := buf.String()
+		require.Contains(t, compiled, "CREATE DATABASE app")
+		require.Contains(t, compiled, "CREATE TABLE app.users")
+		// 01_ must appear before 02_ (alphabetical order)
+		require.Less(t, strings.Index(compiled, "CREATE DATABASE"), strings.Index(compiled, "CREATE TABLE"))
+	})
+
+	t.Run("returns error for non-existent directory", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := schema.Compile("/nonexistent-dir", &buf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("preserves line structure", func(t *testing.T) {


### PR DESCRIPTION
Right now `entrypoint` must point to a single `.sql` file. If we have multiple schema files we want to keep separate, we then still need a hand-written `main.sql` whose only job is listing imports:

```sql
-- db/main.sql
-- housekeeper:import schemas/databases.sql
-- housekeeper:import schemas/tables.sql
-- housekeeper:import schemas/views.sql
```

This is just a directory listing in disguise. When the entrypoint is a directory, housekeeper now reads all `*.sql` files inside in alphabetical order and compiles them in sequence — which is the natural way to organise schemas (e.g. `01_databases.sql`, `02_tables.sql`, `03_views.sql`).

File entrypoints and `-- housekeeper:import` directives continue to work exactly as before. If the entrypoint is already a file, nothing changes.