### PR TITLE
[parser] support TTL action keywords on table-level TTL clause

### DIFF
--- a/pkg/format/table.go
+++ b/pkg/format/table.go
@@ -249,7 +249,11 @@ func (f *Formatter) formatTableClauseType(clause *parser.TableClause) string {
 		return f.keyword("SAMPLE BY") + " " + f.formatExpression(&clause.SampleBy.Expression)
 	}
 	if clause.TTL != nil {
-		return f.keyword("TTL") + " " + f.formatExpression(&clause.TTL.Expression)
+		out := f.keyword("TTL") + " " + f.formatExpression(&clause.TTL.Expression)
+		if action := f.formatTTLAction(clause.TTL.Action); action != "" {
+			out += " " + action
+		}
+		return out
 	}
 	if clause.Settings != nil && len(clause.Settings.Settings) > 0 {
 		return f.formatTableSettings(clause.Settings)
@@ -555,6 +559,24 @@ func getSimpleIdentifierName(expr *parser.Expression) string {
 		return ""
 	}
 	return expr.Or.And.Not.Comparison.Addition.Multiplication.Unary.Primary.Identifier.Name
+}
+
+// formatTTLAction formats the optional TTL action keyword
+func (f *Formatter) formatTTLAction(action *parser.TTLAction) string {
+	if action == nil {
+		return ""
+	}
+	switch {
+	case action.Delete:
+		return f.keyword("DELETE")
+	case action.ToDisk != nil:
+		return f.keyword("TO DISK") + " " + *action.ToDisk
+	case action.ToVolume != nil:
+		return f.keyword("TO VOLUME") + " " + *action.ToVolume
+	case action.Recompress != nil:
+		return f.keyword("RECOMPRESS") + " " + f.formatCodec(&action.Recompress.Codec)
+	}
+	return ""
 }
 
 // formatTableSettings formats the SETTINGS clause

--- a/pkg/parser/table.go
+++ b/pkg/parser/table.go
@@ -218,9 +218,25 @@ type (
 	}
 
 	// TableTTLClause represents table-level TTL expression
+	//   TTL expr [DELETE | TO DISK 'name' | TO VOLUME 'name' | RECOMPRESS CODEC(...)]
 	TableTTLClause struct {
 		TTL        string     `parser:"'TTL'"`
 		Expression Expression `parser:"@@"`
+		Action     *TTLAction `parser:"@@?"`
+	}
+
+	// TTLAction represents the optional action keyword on a table-level TTL clause
+	TTLAction struct {
+		Delete     bool           `parser:"  @'DELETE'"`
+		ToDisk     *string        `parser:"| 'TO' 'DISK' @String"`
+		ToVolume   *string        `parser:"| 'TO' 'VOLUME' @String"`
+		Recompress *TTLRecompress `parser:"| @@"`
+	}
+
+	// TTLRecompress represents the RECOMPRESS CODEC(...) action of a TTL clause
+	TTLRecompress struct {
+		Recompress string      `parser:"'RECOMPRESS'"`
+		Codec      CodecClause `parser:"@@"`
 	}
 
 	// TableSettingsClause represents SETTINGS clause

--- a/pkg/parser/table_stmt_test.go
+++ b/pkg/parser/table_stmt_test.go
@@ -106,6 +106,12 @@ func TestCreateTable(t *testing.T) {
 		{name: "as_on_cluster", sql: `CREATE TABLE events_distributed ON CLUSTER production AS events_local ENGINE = Distributed(production, currentDatabase(), events_local, rand());`},
 		{name: "as_full_options", sql: `CREATE OR REPLACE TABLE IF NOT EXISTS analytics.events_all ON CLUSTER analytics_cluster AS analytics.events_local ENGINE = Distributed(analytics_cluster, analytics, events_local, cityHash64(user_id)) SETTINGS index_granularity = 8192 COMMENT 'Distributed view of events_local';`},
 
+		// TTL action keywords
+		{name: "ttl_delete", sql: `CREATE TABLE archived_events (id UInt64, ts DateTime) ENGINE = MergeTree() ORDER BY id TTL ts + INTERVAL 1 YEAR DELETE;`},
+		{name: "ttl_to_disk", sql: `CREATE TABLE tiered_events (id UInt64, ts DateTime) ENGINE = MergeTree() ORDER BY id TTL ts + INTERVAL 1 MONTH TO DISK 'cold';`},
+		{name: "ttl_to_volume", sql: `CREATE TABLE tiered_events (id UInt64, ts DateTime) ENGINE = MergeTree() ORDER BY id TTL ts + INTERVAL 1 WEEK TO VOLUME 'archive';`},
+		{name: "ttl_recompress", sql: `CREATE TABLE compressed_events (id UInt64, ts DateTime) ENGINE = MergeTree() ORDER BY id TTL ts + INTERVAL 1 DAY RECOMPRESS CODEC(ZSTD(9));`},
+
 		// CREATE TABLE AS with table functions
 		{name: "as_remote", sql: `CREATE TABLE remote_copy AS remote('host:9000', 'db', 'table') ENGINE = MergeTree() ORDER BY id;`},
 		{name: "as_cluster", sql: `CREATE TABLE cluster_data AS cluster('my_cluster', 'default', 'events') ENGINE = MergeTree() ORDER BY id;`},

--- a/pkg/parser/testdata/table/create/ttl_delete.sql
+++ b/pkg/parser/testdata/table/create/ttl_delete.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `archived_events` (
+    `id` UInt64,
+    `ts` DateTime
+)
+ENGINE = MergeTree()
+ORDER BY `id`
+TTL `ts` + INTERVAL 1 YEAR DELETE;

--- a/pkg/parser/testdata/table/create/ttl_recompress.sql
+++ b/pkg/parser/testdata/table/create/ttl_recompress.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `compressed_events` (
+    `id` UInt64,
+    `ts` DateTime
+)
+ENGINE = MergeTree()
+ORDER BY `id`
+TTL `ts` + INTERVAL 1 DAY RECOMPRESS CODEC(ZSTD(9));

--- a/pkg/parser/testdata/table/create/ttl_to_disk.sql
+++ b/pkg/parser/testdata/table/create/ttl_to_disk.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `tiered_events` (
+    `id` UInt64,
+    `ts` DateTime
+)
+ENGINE = MergeTree()
+ORDER BY `id`
+TTL `ts` + INTERVAL 1 MONTH TO DISK 'cold';

--- a/pkg/parser/testdata/table/create/ttl_to_volume.sql
+++ b/pkg/parser/testdata/table/create/ttl_to_volume.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `tiered_events` (
+    `id` UInt64,
+    `ts` DateTime
+)
+ENGINE = MergeTree()
+ORDER BY `id`
+TTL `ts` + INTERVAL 1 WEEK TO VOLUME 'archive';


### PR DESCRIPTION
Hi!

This PR adds the optional action keyword (DELETE | TO DISK 'name' | TO VOLUME 'name' | RECOMPRESS CODEC(...)) to the table-level TTL clause grammar.