### PR TITLE
[parser] allow comments inside engine argument lists

### DIFF
--- a/pkg/format/table.go
+++ b/pkg/format/table.go
@@ -494,27 +494,74 @@ func (f *Formatter) formatTableEngine(engine *parser.TableEngine) string {
 	if engine == nil {
 		return ""
 	}
-
-	result := engine.Name
-	// Always add parentheses for consistency
-	result += "("
-	if len(engine.Parameters) > 0 {
-		var params []string
-		for _, param := range engine.Parameters {
-			if param.Expression != nil {
-				params = append(params, f.formatEngineParameter(param.Expression))
-			} else if param.String != nil {
-				params = append(params, *param.String)
-			} else if param.Number != nil {
-				params = append(params, *param.Number)
-			} else if param.Ident != nil {
-				params = append(params, f.identifier(*param.Ident))
-			}
-		}
-		result += strings.Join(params, ", ")
+	if len(engine.Parameters) == 0 {
+		return engine.Name + "()"
 	}
-	result += ")"
-	return result
+	if engineParametersHaveComments(engine.Parameters) {
+		return f.formatTableEngineMultiline(engine)
+	}
+
+	params := make([]string, 0, len(engine.Parameters))
+	for _, param := range engine.Parameters {
+		if v, ok := f.formatEngineParameterValue(&param); ok {
+			params = append(params, v)
+		}
+	}
+	return engine.Name + "(" + strings.Join(params, ", ") + ")"
+}
+
+// engineParametersHaveComments reports whether any parameter has leading comments
+func engineParametersHaveComments(params []parser.EngineParameter) bool {
+	for _, p := range params {
+		if len(p.LeadingComments) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// formatTableEngineMultiline renders the engine call multi-line with comments interleaved
+func (f *Formatter) formatTableEngineMultiline(engine *parser.TableEngine) string {
+	indent := f.indent(1)
+	var b strings.Builder
+	b.WriteString(engine.Name)
+	b.WriteString("(\n")
+	last := len(engine.Parameters) - 1
+	for i := range engine.Parameters {
+		param := &engine.Parameters[i]
+		for _, c := range param.LeadingComments {
+			b.WriteString(indent)
+			b.WriteString(c)
+			b.WriteString("\n")
+		}
+		v, ok := f.formatEngineParameterValue(param)
+		if !ok {
+			continue
+		}
+		b.WriteString(indent)
+		b.WriteString(v)
+		if i < last {
+			b.WriteString(",")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+// formatEngineParameterValue formats the value portion of an engine parameter
+func (f *Formatter) formatEngineParameterValue(param *parser.EngineParameter) (string, bool) {
+	switch {
+	case param.Expression != nil:
+		return f.formatEngineParameter(param.Expression), true
+	case param.String != nil:
+		return *param.String, true
+	case param.Number != nil:
+		return *param.Number, true
+	case param.Ident != nil:
+		return f.identifier(*param.Ident), true
+	}
+	return "", false
 }
 
 // formatEngineParameter formats an expression in engine parameters with special handling for simple identifiers

--- a/pkg/parser/table.go
+++ b/pkg/parser/table.go
@@ -187,10 +187,11 @@ type (
 
 	// EngineParameter represents a parameter in an ENGINE clause
 	EngineParameter struct {
-		Expression *Expression `parser:"@@"`
-		String     *string     `parser:"| @String"`
-		Number     *string     `parser:"| @Number"`
-		Ident      *string     `parser:"| @(Ident | BacktickIdent)"`
+		LeadingComments []string    `parser:"@(Comment | MultilineComment)*"`
+		Expression      *Expression `parser:"  @@"`
+		String          *string     `parser:"| @String"`
+		Number          *string     `parser:"| @Number"`
+		Ident           *string     `parser:"| @(Ident | BacktickIdent)"`
 	}
 
 	// OrderByClause represents ORDER BY expression

--- a/pkg/parser/table_stmt_test.go
+++ b/pkg/parser/table_stmt_test.go
@@ -106,6 +106,22 @@ func TestCreateTable(t *testing.T) {
 		{name: "as_on_cluster", sql: `CREATE TABLE events_distributed ON CLUSTER production AS events_local ENGINE = Distributed(production, currentDatabase(), events_local, rand());`},
 		{name: "as_full_options", sql: `CREATE OR REPLACE TABLE IF NOT EXISTS analytics.events_all ON CLUSTER analytics_cluster AS analytics.events_local ENGINE = Distributed(analytics_cluster, analytics, events_local, cityHash64(user_id)) SETTINGS index_granularity = 8192 COMMENT 'Distributed view of events_local';`},
 
+		// Comments inside engine argument lists
+		{name: "engine_args_leading_comment", sql: `CREATE TABLE replicated_events (id UInt64, ver UInt64) ENGINE = ReplicatedReplacingMergeTree(
+    -- shared keeper path keeps replicas in sync
+    '/clickhouse/tables/{shard}/{database}/replicated_events',
+    '{replica}',
+    ver
+) ORDER BY id;`},
+		{name: "engine_args_inter_arg_comments", sql: `CREATE TABLE replicated_events (id UInt64, ver UInt64) ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/tables/{shard}/replicated_events',
+    -- per-replica identity from server macros
+    '{replica}',
+    -- monotonic version column for replacement
+    ver
+) ORDER BY id;`},
+		{name: "engine_args_block_comment", sql: `CREATE TABLE replicated_events (id UInt64, ver UInt64) ENGINE = ReplicatedReplacingMergeTree(/* keeper path */ '/p', '{replica}', ver) ORDER BY id;`},
+
 		// CREATE TABLE AS with table functions
 		{name: "as_remote", sql: `CREATE TABLE remote_copy AS remote('host:9000', 'db', 'table') ENGINE = MergeTree() ORDER BY id;`},
 		{name: "as_cluster", sql: `CREATE TABLE cluster_data AS cluster('my_cluster', 'default', 'events') ENGINE = MergeTree() ORDER BY id;`},

--- a/pkg/parser/testdata/table/create/engine_args_block_comment.sql
+++ b/pkg/parser/testdata/table/create/engine_args_block_comment.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `replicated_events` (
+    `id`  UInt64,
+    `ver` UInt64
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    /* keeper path */
+    '/p',
+    '{replica}',
+    `ver`
+)
+ORDER BY `id`;

--- a/pkg/parser/testdata/table/create/engine_args_inter_arg_comments.sql
+++ b/pkg/parser/testdata/table/create/engine_args_inter_arg_comments.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `replicated_events` (
+    `id`  UInt64,
+    `ver` UInt64
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    '/clickhouse/tables/{shard}/replicated_events',
+    -- per-replica identity from server macros
+    '{replica}',
+    -- monotonic version column for replacement
+    `ver`
+)
+ORDER BY `id`;

--- a/pkg/parser/testdata/table/create/engine_args_leading_comment.sql
+++ b/pkg/parser/testdata/table/create/engine_args_leading_comment.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `replicated_events` (
+    `id`  UInt64,
+    `ver` UInt64
+)
+ENGINE = ReplicatedReplacingMergeTree(
+    -- shared keeper path keeps replicas in sync
+    '/clickhouse/tables/{shard}/{database}/replicated_events',
+    '{replica}',
+    `ver`
+)
+ORDER BY `id`;


### PR DESCRIPTION
Hi!

This PR adds LeadingComments to EngineParameter so comments before each arg inside an engine's parenthesized argument list parse cleanly.

The formatter switches to a multi-line render when any parameter has comments.

Comments just before the closing parenthesis still do not work.