### PR TITLE
fix(format): don't double-quote COMMENT in MODIFY COLUMN

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.4
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.41.0
+	github.com/IBM/fp-go/v2 v2.1.22
 	github.com/alecthomas/participle/v2 v2.1.4
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ClickHouse/ch-go v0.69.0 h1:nO0OJkpxOlN/eaXFj0KzjTz5p7vwP1/y3GN4qc5z/
 github.com/ClickHouse/ch-go v0.69.0/go.mod h1:9XeZpSAT4S0kVjOpaJ5186b7PY/NH/hhF8R6u0WIjwg=
 github.com/ClickHouse/clickhouse-go/v2 v2.41.0 h1:JbLKMXLEkW0NMalMgI+GYb6FVZtpaMVEzQa/HC1ZMRE=
 github.com/ClickHouse/clickhouse-go/v2 v2.41.0/go.mod h1:/RoTHh4aDA4FOCIQggwsiOwO7Zq1+HxQ0inef0Au/7k=
+github.com/IBM/fp-go/v2 v2.1.22 h1:wZTjgIxkHsILeykIdjiAoy9a+L7iuMpJzMgeIOxMKpQ=
+github.com/IBM/fp-go/v2 v2.1.22/go.mod h1:b7y1r0BAYSHsbTbuM4wgQr+x0kC7aqVhf/o2PUGgBLk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/pkg/cmd/bootstrap_test.go
+++ b/pkg/cmd/bootstrap_test.go
@@ -30,13 +30,19 @@ func TestBootstrapCommand_RequiresConfig(t *testing.T) {
 }
 
 func TestBootstrapCommand_RequiresURL(t *testing.T) {
-	// Test that bootstrap command requires URL flag
+	// HOUSEKEEPER_DATABASE_URL must be absent so the Required: true check fires.
+	// When set (e.g. by devenv), urfave/cli satisfies the flag via its EnvVars
+	// source and the action runs instead of returning a validation error.
+	if orig, had := os.LookupEnv("HOUSEKEEPER_DATABASE_URL"); had {
+		os.Unsetenv("HOUSEKEEPER_DATABASE_URL")
+		t.Cleanup(func() { os.Setenv("HOUSEKEEPER_DATABASE_URL", orig) })
+	}
+
 	fixture := testutil.TestProject(t)
 	defer fixture.Cleanup()
 
 	command := bootstrap(fixture.Project, fixture.Config)
 
-	// Create a test CLI app to test flag validation
 	app := &cli.Command{
 		Name:   "test",
 		Flags:  command.Flags,
@@ -44,8 +50,7 @@ func TestBootstrapCommand_RequiresURL(t *testing.T) {
 		Before: command.Before,
 	}
 
-	ctx := context.Background()
-	err := app.Run(ctx, []string{"test"}) // No --url flag
+	err := app.Run(context.Background(), []string{"test"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Required flag \"url\" not set")
 }

--- a/pkg/cmd/rehash.go
+++ b/pkg/cmd/rehash.go
@@ -6,12 +6,34 @@ import (
 	"os"
 	"path/filepath"
 
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
 	"github.com/pkg/errors"
+	"github.com/pseudomuto/housekeeper/pkg/config"
 	"github.com/pseudomuto/housekeeper/pkg/consts"
 	"github.com/pseudomuto/housekeeper/pkg/migrator"
 	"github.com/pseudomuto/housekeeper/pkg/project"
 	"github.com/urfave/cli/v3"
 )
+
+// resolveMigrationsDir picks the migrations directory honouring the user's
+// housekeeper.yaml config (cfg.Dir) when set, falling back to the project's
+// default db/migrations layout otherwise. Relative paths are resolved against
+// the project root so the command works regardless of the caller's CWD.
+func resolveMigrationsDir(p *project.Project, cfg *config.Config) string {
+	resolve := func(d string) string {
+		if filepath.IsAbs(d) {
+			return d
+		}
+		return filepath.Join(p.Dir(), d)
+	}
+	return F.Pipe3(
+		O.FromNillable(cfg),
+		O.Map(func(c *config.Config) string { return c.Dir }),
+		O.Chain(O.FromPredicate(func(s string) bool { return s != "" })),
+		O.Fold(p.MigrationsDir, resolve),
+	)
+}
 
 // rehash creates a CLI command for regenerating the sum file for all migrations.
 //
@@ -34,12 +56,12 @@ import (
 //
 // The command will output the status of the rehashing operation and indicate
 // how many migration files were processed.
-func rehash(p *project.Project) *cli.Command {
+func rehash(p *project.Project, cfg *config.Config) *cli.Command {
 	return &cli.Command{
 		Name:  "rehash",
 		Usage: "Regenerate the sum file for all migrations",
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			migrationsDir := p.MigrationsDir()
+			migrationsDir := resolveMigrationsDir(p, cfg)
 
 			// Check if migrations directory exists
 			if _, err := os.Stat(migrationsDir); os.IsNotExist(err) {
@@ -87,6 +109,6 @@ func rehash(p *project.Project) *cli.Command {
 // TestableRehash creates a testable version of the rehash command for use in unit tests.
 // This function exposes the same functionality as the main rehash command but allows
 // for easier testing by accepting a project parameter directly.
-func TestableRehash(p *project.Project) *cli.Command {
-	return rehash(p)
+func TestableRehash(p *project.Project, cfg *config.Config) *cli.Command {
+	return rehash(p, cfg)
 }

--- a/pkg/cmd/rehash_test.go
+++ b/pkg/cmd/rehash_test.go
@@ -20,7 +20,7 @@ func TestRehashCommand_WithMigrations(t *testing.T) {
 		WithMigrations(testutil.MinimalMigrations())
 	defer fixture.Cleanup()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -53,7 +53,7 @@ func TestRehashCommand_EmptyMigrationsDirectory(t *testing.T) {
 	// Ensure migrations directory exists but is empty
 	testutil.RequireDirEmpty(t, fixture.GetMigrationsDir())
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -83,7 +83,7 @@ func TestRehashCommand_NoMigrationsDirectory(t *testing.T) {
 	err := os.RemoveAll(fixture.GetMigrationsDir())
 	require.NoError(t, err)
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -111,7 +111,7 @@ func TestRehashCommand_UpdatesExistingSumFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(originalContent), "oldhash")
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -141,7 +141,7 @@ func TestRehashCommand_WithMultipleMigrations(t *testing.T) {
 		WithMigrations(testutil.SampleMigrations())
 	defer fixture.Cleanup()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -175,7 +175,7 @@ func TestRehashCommand_FilePermissions(t *testing.T) {
 		WithMigrations(testutil.MinimalMigrations())
 	defer fixture.Cleanup()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -200,7 +200,7 @@ func TestRehashCommand_InvalidMigrations(t *testing.T) {
 		})
 	defer fixture.Cleanup()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -226,7 +226,7 @@ func TestRehashCommand_MigrationCount(t *testing.T) {
 		WithMigrations(migrations)
 	defer fixture.Cleanup()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -247,7 +247,7 @@ func TestRehashCommand_CommandStructure(t *testing.T) {
 	fixture := testutil.TestProject(t)
 	defer fixture.Cleanup()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	require.Equal(t, "rehash", command.Name)
 	require.Equal(t, "Regenerate the sum file for all migrations", command.Usage)
@@ -273,7 +273,7 @@ func TestRehashCommand_ReadOnlyMigrationsDir(t *testing.T) {
 		_ = os.Chmod(fixture.GetMigrationsDir(), consts.ModeDir)
 	}()
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -302,7 +302,7 @@ func TestRehashCommand_WithSubdirectories(t *testing.T) {
 	err = os.WriteFile(txtFile, []byte("Not a migration"), consts.ModeFile)
 	require.NoError(t, err)
 
-	command := rehash(fixture.Project)
+	command := rehash(fixture.Project, fixture.Config)
 
 	ctx := context.Background()
 	var buf bytes.Buffer
@@ -325,7 +325,7 @@ func TestTestableRehash(t *testing.T) {
 		WithMigrations(testutil.MinimalMigrations())
 	defer fixture.Cleanup()
 
-	command := TestableRehash(fixture.Project)
+	command := TestableRehash(fixture.Project, fixture.Config)
 
 	require.Equal(t, "rehash", command.Name)
 	require.NotNil(t, command.Action)

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pseudomuto/housekeeper/pkg/docker"
 	"github.com/pseudomuto/housekeeper/pkg/migrator"
 	"github.com/pseudomuto/housekeeper/pkg/parser"
+	"github.com/pseudomuto/housekeeper/pkg/podman"
 	schemapkg "github.com/pseudomuto/housekeeper/pkg/schema"
 )
 
@@ -39,7 +40,14 @@ func runContainer(ctx context.Context, w io.Writer, opts docker.DockerOptions, c
 		}
 	}
 
-	// 2. Create and start container
+	// 2. Create and start container.
+	// Inject auto-detect resolver if the caller didn't supply one: under Podman
+	// (detected via HOUSEKEEPER_RUNTIME, CONTAINER_HOST, DOCKER_HOST, or socket
+	// path) the Podman resolver connects via bridge IP + container port, which
+	// works correctly in rootless mode. Under Docker the Docker resolver is used.
+	if opts.AddressResolver == nil {
+		opts.AddressResolver = podman.NewAutoDetectResolver()
+	}
 	container, err := docker.NewWithOptions(dockerClient, opts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create ClickHouse container")

--- a/pkg/docker/address.go
+++ b/pkg/docker/address.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/pkg/errors"
+)
+
+// ContainerAddress holds the resolved network coordinates for a running container.
+// Different container runtimes expose connectivity differently; this struct normalises
+// the result so the rest of the codebase never needs to know the origin.
+type ContainerAddress struct {
+	// Host is the IP address or hostname used to reach the container.
+	Host string
+
+	// NativePort is the ClickHouse native (binary) protocol port.
+	NativePort int
+
+	// HTTPPort is the ClickHouse HTTP interface port.
+	HTTPPort int
+}
+
+// AddressResolver resolves the network address of a running container.
+//
+// Strategy Pattern: different runtimes (Docker, Podman) require fundamentally different
+// address resolution strategies:
+//
+//   - Docker publishes each container port to a randomly-assigned host port on localhost.
+//     The correct address is localhost:<randomHostPort>.
+//
+//   - Podman rootless does not reliably forward ports to localhost through the compat API.
+//     The correct address is the container's direct bridge IP + the container port.
+//
+// Callers inject the desired resolver into DockerOptions.AddressResolver. When nil,
+// ClickHouseContainer defaults to DockerAddressResolver (Docker-compatible behaviour).
+// Use the podman package to obtain a Podman-aware resolver.
+type AddressResolver interface {
+	// Resolve returns the network address for the named container.
+	// The provided DockerClient is used solely for inspection; callers must not mutate it.
+	Resolve(ctx context.Context, client DockerClient, containerName string) (*ContainerAddress, error)
+}
+
+// DockerAddressResolver is the default AddressResolver for standard Docker environments.
+//
+// It reads the randomly-assigned host-port bindings that Docker creates when a container
+// is started with published ports and returns localhost:<hostPort> for each service.
+// This is the correct strategy for Docker Desktop, Docker Engine, and any runtime whose
+// compat API properly sets up port-forwarding to the loopback interface.
+type DockerAddressResolver struct{}
+
+// Resolve implements AddressResolver for Docker.
+func (r *DockerAddressResolver) Resolve(ctx context.Context, client DockerClient, containerName string) (*ContainerAddress, error) {
+	inspect, err := client.ContainerInspect(ctx, containerName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to inspect container %q", containerName)
+	}
+
+	nativePort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHousePort))
+	nativeBindings, ok := inspect.NetworkSettings.Ports[nativePort]
+	if !ok || len(nativeBindings) == 0 {
+		return nil, errors.Errorf("container %q: native port %d is not mapped", containerName, DefaultClickHousePort)
+	}
+
+	httpPort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHouseHTTPPort))
+	httpBindings, ok := inspect.NetworkSettings.Ports[httpPort]
+	if !ok || len(httpBindings) == 0 {
+		return nil, errors.Errorf("container %q: HTTP port %d is not mapped", containerName, DefaultClickHouseHTTPPort)
+	}
+
+	nativeMapped, err := strconv.Atoi(nativeBindings[0].HostPort)
+	if err != nil {
+		return nil, errors.Wrapf(err, "container %q: invalid native host port %q", containerName, nativeBindings[0].HostPort)
+	}
+
+	httpMapped, err := strconv.Atoi(httpBindings[0].HostPort)
+	if err != nil {
+		return nil, errors.Wrapf(err, "container %q: invalid HTTP host port %q", containerName, httpBindings[0].HostPort)
+	}
+
+	return &ContainerAddress{
+		Host:       "localhost",
+		NativePort: nativeMapped,
+		HTTPPort:   httpMapped,
+	}, nil
+}

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -3,270 +3,197 @@ package docker
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"time"
 
-	"github.com/docker/go-connections/nat"
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
+	R "github.com/IBM/fp-go/v2/result"
 	"github.com/pkg/errors"
 )
 
 const (
-	// DefaultClickHousePort is the default port for ClickHouse server
-	DefaultClickHousePort = 9000
-
-	// DefaultClickHouseHTTPPort is the default HTTP port for ClickHouse server
+	DefaultClickHousePort     = 9000
 	DefaultClickHouseHTTPPort = 8123
+
+	readinessDeadline     = 120 * time.Second
+	readinessPollInterval = 500 * time.Millisecond
+	readinessDialTimeout  = 2 * time.Second
 )
 
 type (
-	// DockerOptions represents options for running ClickHouse in Docker
+	// DockerOptions configures a ClickHouseContainer.
 	DockerOptions struct {
-		// Version is the ClickHouse version to run (default: latest)
+		// Version is the ClickHouse image tag to use (default: latest).
 		Version string
 
-		// ConfigDir is the optional ClickHouse config directory path to mount (relative paths will be converted to absolute)
+		// ConfigDir is an optional host path to mount as /etc/clickhouse-server/config.d.
+		// Relative paths are resolved to absolute before mounting.
 		ConfigDir string
 
-		// Name is the container name (default: housekeeper-dev)
+		// Name is the container name (default: housekeeper-dev).
 		Name string
+
+		// AddressResolver determines how to obtain the container's network address.
+		// When nil, DockerAddressResolver is used (localhost + mapped host ports).
+		// Use podman.NewPodmanAddressResolver() or podman.NewAutoDetectResolver() for Podman.
+		AddressResolver AddressResolver
 	}
 
-	// ClickHouseContainer manages ClickHouse Docker containers for development
+	// ClickHouseContainer manages a ClickHouse container for local development.
 	ClickHouseContainer struct {
-		options DockerOptions
-		engine  *engine
-		running bool
-		ports   map[int]int // hostPort -> containerPort mapping
+		options         DockerOptions
+		engine          *engine
+		running         bool
+		addressResolver AddressResolver
 	}
 )
 
-// New creates a new ClickHouse Docker container with default options
-//
-// Example:
-//
-//	// Create Docker client
-//	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//	defer cli.Close()
-//
-//	container, err := docker.New(cli)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//
-//	// Start ClickHouse container
-//	if err := container.Start(ctx); err != nil {
-//		log.Fatal(err)
-//	}
-//	defer container.Stop(ctx)
+// New creates a ClickHouseContainer with default options.
 func New(dockerClient DockerClient) (*ClickHouseContainer, error) {
 	return NewWithOptions(dockerClient, DockerOptions{})
 }
 
-// NewWithOptions creates a new ClickHouse Docker container with custom options
-//
-// Example:
-//
-//	// Create Docker client
-//	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//	defer cli.Close()
-//
-//	opts := docker.DockerOptions{
-//		Version:   "25.7",
-//		ConfigDir: "/path/to/project/db/config.d",
-//	}
-//	container, err := docker.NewWithOptions(cli, opts)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//
-//	// Start ClickHouse container
-//	if err := container.Start(ctx); err != nil {
-//		log.Fatal(err)
-//	}
-//	defer container.Stop(ctx)
+// NewWithOptions creates a ClickHouseContainer with the given options.
 func NewWithOptions(dockerClient DockerClient, opts DockerOptions) (*ClickHouseContainer, error) {
-	engine := newEngine(dockerClient)
-
+	resolver := opts.AddressResolver
+	if resolver == nil {
+		resolver = &DockerAddressResolver{}
+	}
 	return &ClickHouseContainer{
-		options: opts,
-		engine:  engine,
-		running: false,
-		ports:   make(map[int]int),
+		options:         opts,
+		engine:          newEngine(dockerClient),
+		addressResolver: resolver,
 	}, nil
 }
 
-// Start starts a ClickHouse Docker container with the configured version
+func (c *ClickHouseContainer) containerName() string {
+	return O.MonadGetOrElse(O.FromNonZero[string]()(c.options.Name), F.Constant("housekeeper-dev"))
+}
+
+// Start pulls the image, cleans up any stale container with the same name, then starts a
+// fresh container and waits for ClickHouse to accept TCP connections.
+//
+// Stale cleanup prevents "name already in use" failures when a previous run was interrupted
+// before Stop was called.
 func (c *ClickHouseContainer) Start(ctx context.Context) error {
 	if c.running {
 		return errors.New("container is already running")
 	}
 
-	// Determine ClickHouse version to use
-	version := c.options.Version
-	if version == "" {
-		version = "latest"
+	version := O.MonadGetOrElse(O.FromNonZero[string]()(c.options.Version), F.Constant("latest"))
+
+	containerName := c.containerName()
+
+	if err := c.engine.StopIfExists(ctx, containerName); err != nil {
+		return errors.Wrapf(err, "failed to clean up existing container %q", containerName)
 	}
 
-	// Determine container name to use
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	// Build container options
 	containerOpts := ContainerOptions{
 		Name:  containerName,
 		Image: fmt.Sprintf("clickhouse/clickhouse-server:%s-alpine", version),
-		Env: map[string]string{
-			"CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT": "1",
-		},
+		Env:   map[string]string{"CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT": "1"},
 		Ports: map[int]int{
-			// Use negative values as placeholders for dynamic port assignment
-			-1: DefaultClickHousePort,     // Let Docker assign random host port for native port 9000
-			-2: DefaultClickHouseHTTPPort, // Let Docker assign random host port for HTTP port 8123
+			-1: DefaultClickHousePort,
+			-2: DefaultClickHouseHTTPPort,
 		},
 	}
 
-	// Add config directory mount if specified
 	if c.options.ConfigDir != "" {
-		// Convert to absolute path to ensure proper mounting
 		absConfigDir, err := filepath.Abs(c.options.ConfigDir)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get absolute path for ConfigDir: %s", c.options.ConfigDir)
 		}
+		containerOpts.Volumes = []ContainerVolume{{
+			HostPath:      absConfigDir,
+			ContainerPath: "/etc/clickhouse-server/config.d",
+			ReadOnly:      true,
+		}}
+	}
 
-		containerOpts.Volumes = []ContainerVolume{
-			{
-				HostPath:      absConfigDir,
-				ContainerPath: "/etc/clickhouse-server/config.d",
-				ReadOnly:      true,
-			},
+	return R.ToError(F.Pipe2(
+		R.TryCatchError(struct{}{}, errors.Wrap(c.engine.Pull(ctx, containerOpts.Image), "failed to pull ClickHouse image")),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, errors.Wrap(c.engine.Start(ctx, containerOpts), "failed to start ClickHouse container"))
+		}),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			c.running = true
+			return R.TryCatchError(struct{}{}, errors.Wrap(c.waitForReady(ctx), "ClickHouse container failed to become ready"))
+		}),
+	))
+}
+
+// waitForReady polls the ClickHouse native port via TCP until it accepts connections
+// or readinessDeadline elapses. The address is resolved through the injected
+// AddressResolver so Podman bridge IPs work without special-casing.
+func (c *ClickHouseContainer) waitForReady(ctx context.Context) error {
+	addr, err := c.addressResolver.Resolve(ctx, c.engine.client, c.containerName())
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve container address for readiness check")
+	}
+
+	target := net.JoinHostPort(addr.Host, fmt.Sprintf("%d", addr.NativePort))
+	deadline := time.Now().Add(readinessDeadline)
+
+	for time.Now().Before(deadline) {
+		conn, dialErr := net.DialTimeout("tcp", target, readinessDialTimeout)
+		if dialErr == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(readinessPollInterval):
 		}
 	}
 
-	// Pull the image first
-	if err := c.engine.Pull(ctx, containerOpts.Image); err != nil {
-		return errors.Wrap(err, "failed to pull ClickHouse image")
-	}
-
-	// Start the container
-	if err := c.engine.Start(ctx, containerOpts); err != nil {
-		return errors.Wrap(err, "failed to start ClickHouse container")
-	}
-
-	c.running = true
-
-	// Wait for ClickHouse to be ready
-	if err := c.waitForReady(ctx); err != nil {
-		return errors.Wrap(err, "ClickHouse container failed to become ready")
-	}
-
-	return nil
+	return errors.Errorf("ClickHouse at %s failed to become ready within %s", target, readinessDeadline)
 }
 
-// waitForReady waits for ClickHouse to be ready to accept connections
-func (c *ClickHouseContainer) waitForReady(ctx context.Context) error {
-	// Simple wait implementation - just wait a few seconds
-	// In a more sophisticated implementation, we would check HTTP endpoint
-	select {
-	case <-time.After(10 * time.Second):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-// Stop stops and removes the ClickHouse Docker container
+// Stop stops and removes the container.
 func (c *ClickHouseContainer) Stop(ctx context.Context) error {
 	if !c.running {
-		return nil // Already stopped
+		return nil
 	}
-
-	// Determine container name
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	err := c.engine.Stop(ctx, containerName)
+	err := c.engine.Stop(ctx, c.containerName())
 	c.running = false
-
 	if err != nil {
 		return errors.Wrap(err, "failed to stop ClickHouse container")
 	}
-
 	return nil
 }
 
-// GetDSN returns the DSN for connecting to the Docker ClickHouse instance
+// GetDSN returns the native-protocol DSN for the running container.
 func (c *ClickHouseContainer) GetDSN(ctx context.Context) (string, error) {
 	if !c.running {
 		return "", errors.New("container is not running")
 	}
-
-	// Determine container name
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	// Inspect container to get port mapping
-	inspect, err := c.engine.client.ContainerInspect(ctx, containerName)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to inspect container")
-	}
-
-	// Find the mapped port for ClickHouse native port (9000)
-	nativePort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHousePort))
-	bindings, exists := inspect.NetworkSettings.Ports[nativePort]
-	if !exists || len(bindings) == 0 {
-		return "", errors.New("ClickHouse native port not exposed")
-	}
-
-	host := "localhost"
-	port := bindings[0].HostPort
-
-	return fmt.Sprintf("clickhouse://default:@%s:%s/", host, port), nil
+	addr, err := c.addressResolver.Resolve(ctx, c.engine.client, c.containerName())
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(addr, errors.Wrap(err, "failed to resolve container address")),
+		R.Map(func(addr *ContainerAddress) string {
+			return fmt.Sprintf("clickhouse://default:@%s:%d/", addr.Host, addr.NativePort)
+		}),
+	))
 }
 
-// GetHTTPDSN returns the HTTP DSN for connecting to the Docker ClickHouse instance
+// GetHTTPDSN returns the HTTP DSN for the running container.
 func (c *ClickHouseContainer) GetHTTPDSN(ctx context.Context) (string, error) {
 	if !c.running {
 		return "", errors.New("container is not running")
 	}
-
-	// Determine container name
-	containerName := c.options.Name
-	if containerName == "" {
-		containerName = "housekeeper-dev"
-	}
-
-	// Inspect container to get port mapping
-	inspect, err := c.engine.client.ContainerInspect(ctx, containerName)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to inspect container")
-	}
-
-	// Find the mapped port for ClickHouse HTTP port (8123)
-	httpPort := nat.Port(fmt.Sprintf("%d/tcp", DefaultClickHouseHTTPPort))
-	bindings, exists := inspect.NetworkSettings.Ports[httpPort]
-	if !exists || len(bindings) == 0 {
-		return "", errors.New("ClickHouse HTTP port not exposed")
-	}
-
-	host := "localhost"
-	port := bindings[0].HostPort
-
-	return fmt.Sprintf("http://%s:%s", host, port), nil
+	addr, err := c.addressResolver.Resolve(ctx, c.engine.client, c.containerName())
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(addr, errors.Wrap(err, "failed to resolve container address")),
+		R.Map(func(addr *ContainerAddress) string {
+			return fmt.Sprintf("http://%s:%d", addr.Host, addr.HTTPPort)
+		}),
+	))
 }
 
-// IsRunning returns true if the container is currently running
+// IsRunning reports whether the container is currently running.
 func (c *ClickHouseContainer) IsRunning() bool {
 	return c.running
 }

--- a/pkg/docker/engine.go
+++ b/pkg/docker/engine.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 	"strings"
 
+	A "github.com/IBM/fp-go/v2/array"
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
+	R "github.com/IBM/fp-go/v2/result"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -16,6 +20,18 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
+
+// isContainerNotFound reports whether err indicates the container was not found.
+// Handles Docker SDK error messages and the errdefs package across SDK versions.
+func isContainerNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return A.Any(F.Bind1st(strings.Contains, msg))([]string{
+		"no such container", "not found", "does not exist",
+	})
+}
 
 var runningContainers = filters.Arg("status", "running")
 
@@ -58,147 +74,129 @@ type (
 	}
 )
 
-// newEngine creates a new Docker engine instance for managing Docker operations.
-// The Docker client should be initialized and connected before passing to this constructor.
 func newEngine(cl DockerClient) *engine {
-	return &engine{
-		client: cl,
-	}
+	return &engine{client: cl}
 }
 
 func (c *engine) Pull(ctx context.Context, img string) error {
 	out, err := c.client.ImagePull(ctx, img, image.PullOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to pull image: %s", img)
-	}
-
-	defer func() { _ = out.Close() }()
-	_, _ = io.Copy(os.Stdout, out)
-	return nil
+	return R.ToError(F.Pipe1(
+		R.TryCatchError(out, errors.Wrapf(err, "failed to pull image: %s", img)),
+		R.Chain(func(out io.ReadCloser) R.Result[struct{}] {
+			defer func() { _ = out.Close() }()
+			_, _ = io.Copy(os.Stdout, out)
+			return R.Of(struct{}{})
+		}),
+	))
 }
 
 func (c *engine) Start(ctx context.Context, opts ContainerOptions) error {
-	// Build environment variables
 	env := make([]string, 0, len(opts.Env))
 	for key, value := range opts.Env {
 		env = append(env, fmt.Sprintf("%s=%s", key, value))
 	}
 
-	// Build port bindings
 	exposedPorts := make(nat.PortSet)
 	portBindings := make(nat.PortMap)
 	for hostPort, containerPort := range opts.Ports {
 		port := nat.Port(fmt.Sprintf("%d/tcp", containerPort))
 		exposedPorts[port] = struct{}{}
-
-		// If hostPort is 0 or negative, let Docker assign a random port
-		hostPortStr := ""
-		if hostPort > 0 {
-			hostPortStr = strconv.Itoa(hostPort)
-		}
-
-		portBindings[port] = []nat.PortBinding{
-			{
-				HostPort: hostPortStr,
-			},
-		}
+		hostPortStr := O.Fold(F.Constant(""), strconv.Itoa)(
+			O.FromPredicate(func(p int) bool { return p > 0 })(hostPort),
+		)
+		portBindings[port] = []nat.PortBinding{{HostPort: hostPortStr}}
 	}
 
-	// Build volume bindings
-	binds := make([]string, len(opts.Volumes))
-	for i, volume := range opts.Volumes {
-		bind := fmt.Sprintf("%s:%s", volume.HostPath, volume.ContainerPath)
-		if volume.ReadOnly {
-			bind += ":ro"
-		}
-		binds[i] = bind
-	}
+	binds := A.Map(func(v ContainerVolume) string {
+		return fmt.Sprintf("%s:%s", v.HostPath, v.ContainerPath) +
+			O.Fold(F.Constant(""), F.Constant1[bool, string](":ro"))(O.FromNonZero[bool]()(v.ReadOnly))
+	})(opts.Volumes)
 
 	resp, err := c.client.ContainerCreate(
 		ctx,
-		&container.Config{
-			Image:        opts.Image,
-			Env:          env,
-			ExposedPorts: exposedPorts,
-		},
-		&container.HostConfig{
-			PortBindings: portBindings,
-			Binds:        binds,
-		},
-		nil,
-		nil,
-		opts.Name,
+		&container.Config{Image: opts.Image, Env: env, ExposedPorts: exposedPorts},
+		&container.HostConfig{PortBindings: portBindings, Binds: binds},
+		nil, nil, opts.Name,
 	)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create container: %s", opts.Name)
-	}
-
-	if err := c.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
-		return errors.Wrapf(err, "failed to start container: %s", opts.Name)
-	}
-
-	return nil
+	return R.ToError(F.Pipe1(
+		R.TryCatchError(resp, errors.Wrapf(err, "failed to create container: %s", opts.Name)),
+		R.Chain(func(resp container.CreateResponse) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, errors.Wrapf(
+				c.client.ContainerStart(ctx, resp.ID, container.StartOptions{}),
+				"failed to start container: %s", opts.Name,
+			))
+		}),
+	))
 }
 
 func (c *engine) List(ctx context.Context) ([]*Container, error) {
-	list, err := c.client.ContainerList(ctx, container.ListOptions{
-		Filters: filters.NewArgs(runningContainers),
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list running containers")
-	}
-
-	res := make([]*Container, len(list))
-	for i, c := range list {
-		// Map slice of names to remove leading "/" prefix
-		names := make([]string, len(c.Names))
-		for j, name := range c.Names {
-			names[j] = strings.TrimPrefix(name, "/")
-		}
-
-		res[i] = &Container{
-			Names:  names,
-			Image:  c.Image,
-			State:  c.State,
-			Status: c.Status,
-		}
-	}
-
-	return res, nil
+	list, err := c.client.ContainerList(ctx, container.ListOptions{Filters: filters.NewArgs(runningContainers)})
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(list, errors.Wrap(err, "failed to list running containers")),
+		R.Map(A.Map(func(s container.Summary) *Container {
+			return &Container{
+				Names:  A.Map(F.Bind2nd(strings.TrimPrefix, "/"))(s.Names),
+				Image:  s.Image,
+				State:  s.State,
+				Status: s.Status,
+			}
+		})),
+	))
 }
 
 func (c *engine) Stop(ctx context.Context, nameOrID string) error {
 	timeout := 30
-	if err := c.client.ContainerStop(ctx, nameOrID, container.StopOptions{
-		Timeout: &timeout,
-	}); err != nil {
-		return errors.Wrapf(err, "failed to stop container: %s", nameOrID)
-	}
+	return R.ToError(F.Pipe1(
+		R.TryCatchError(struct{}{}, errors.Wrapf(
+			c.client.ContainerStop(ctx, nameOrID, container.StopOptions{Timeout: &timeout}),
+			"failed to stop container: %s", nameOrID,
+		)),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, errors.Wrapf(
+				c.client.ContainerRemove(ctx, nameOrID, container.RemoveOptions{Force: true}),
+				"failed to remove container: %s", nameOrID,
+			))
+		}),
+	))
+}
 
-	if err := c.client.ContainerRemove(ctx, nameOrID, container.RemoveOptions{
-		Force: true,
-	}); err != nil {
-		return errors.Wrapf(err, "failed to remove container: %s", nameOrID)
+// StopIfExists stops and removes nameOrID if it exists, silently ignoring not-found errors.
+// Callers can invoke this unconditionally before creating a container to avoid
+// "name already in use" failures when a previous run left a stale container.
+func (c *engine) StopIfExists(ctx context.Context, nameOrID string) error {
+	timeout := 10
+	orWrap := func(msg string) func(R.Result[struct{}]) R.Result[struct{}] {
+		return R.OrElse[struct{}](func(err error) R.Result[struct{}] {
+			if isContainerNotFound(err) {
+				return R.Of(struct{}{})
+			}
+			return R.Left[struct{}](errors.Wrap(err, msg))
+		})
 	}
-
-	return nil
+	return R.ToError(F.Pipe3(
+		R.TryCatchError(struct{}{}, c.client.ContainerStop(ctx, nameOrID, container.StopOptions{Timeout: &timeout})),
+		orWrap(fmt.Sprintf("failed to stop container %q", nameOrID)),
+		R.Chain(func(_ struct{}) R.Result[struct{}] {
+			return R.TryCatchError(struct{}{}, c.client.ContainerRemove(ctx, nameOrID, container.RemoveOptions{Force: true}))
+		}),
+		orWrap(fmt.Sprintf("failed to remove container %q", nameOrID)),
+	))
 }
 
 func (c *engine) Get(ctx context.Context, nameOrID string) (*Container, error) {
 	inspect, err := c.client.ContainerInspect(ctx, nameOrID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to inspect container: %s", nameOrID)
-	}
-
-	names := make([]string, len(inspect.Name))
-	if inspect.Name != "" {
-		names = []string{strings.TrimPrefix(inspect.Name, "/")}
-	}
-
-	return &Container{
-		Names:  names,
-		Image:  inspect.Config.Image,
-		State:  inspect.State.Status,
-		Status: inspect.State.Status,
-	}, nil
+	return R.UnwrapError(F.Pipe1(
+		R.TryCatchError(inspect, errors.Wrapf(err, "failed to inspect container: %s", nameOrID)),
+		R.Map(func(inspect container.InspectResponse) *Container {
+			names := O.Fold(F.Constant([]string{}), F.Flow2(F.Bind2nd(strings.TrimPrefix, "/"), A.Of[string]))(
+				O.FromNonZero[string]()(inspect.Name),
+			)
+			return &Container{
+				Names:  names,
+				Image:  inspect.Config.Image,
+				State:  inspect.State.Status,
+				Status: inspect.State.Status,
+			}
+		}),
+	))
 }

--- a/pkg/format/base.go
+++ b/pkg/format/base.go
@@ -56,10 +56,12 @@ func (d *DDLFormatter) buildDropStatement(objectType string, ifExists bool, name
 }
 
 // appendOnCluster appends ON CLUSTER clause if present.
+// Delegates to clusterName() so that macro references like '{cluster}' are emitted
+// verbatim while plain identifiers are backtick-quoted.
 func (d *DDLFormatter) appendOnCluster(parts []string, cluster *string) []string {
 	if cluster != nil {
 		parts = append(parts, d.formatter.keyword("ON CLUSTER"))
-		parts = append(parts, d.formatter.identifier(*cluster))
+		parts = append(parts, d.formatter.clusterName(*cluster))
 	}
 	return parts
 }

--- a/pkg/format/database.go
+++ b/pkg/format/database.go
@@ -40,7 +40,7 @@ func (f *Formatter) alterDatabase(w io.Writer, stmt *parser.AlterDatabaseStmt) e
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// Action
@@ -76,7 +76,7 @@ func (f *Formatter) attachDatabase(w io.Writer, stmt *parser.AttachDatabaseStmt)
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		_, err := w.Write([]byte(strings.Join(parts, " ") + ";"))

--- a/pkg/format/dictionary.go
+++ b/pkg/format/dictionary.go
@@ -29,7 +29,7 @@ func (f *Formatter) createDictionary(w io.Writer, stmt *parser.CreateDictionaryS
 		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 		if stmt.OnCluster != nil {
-			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		lines = append(lines, strings.Join(headerParts, " ")+" (")

--- a/pkg/format/formatter.go
+++ b/pkg/format/formatter.go
@@ -445,6 +445,13 @@ func (f *Formatter) identifier(name string) string {
 	return utils.BacktickIdentifier(name)
 }
 
+// clusterName formats a cluster name for ON CLUSTER clauses.
+// Plain identifiers are backtick-quoted; ClickHouse macro references (e.g. '{cluster}')
+// are returned verbatim so that generated DDL is portable across clusters.
+func (f *Formatter) clusterName(name string) string {
+	return utils.FormatClusterName(name)
+}
+
 // commentable represents any statement that can have leading and trailing comments
 type commentable interface {
 	GetLeadingComments() []string

--- a/pkg/format/function.go
+++ b/pkg/format/function.go
@@ -23,7 +23,7 @@ func (f *Formatter) formatCreateFunction(w io.Writer, stmt *parser.CreateFunctio
 			if _, err := w.Write([]byte(" " + f.keyword("on") + " " + f.keyword("cluster") + " ")); err != nil {
 				return err
 			}
-			if _, err := w.Write([]byte(f.identifier(*stmt.OnCluster))); err != nil {
+			if _, err := w.Write([]byte(f.clusterName(*stmt.OnCluster))); err != nil {
 				return err
 			}
 		}
@@ -94,7 +94,7 @@ func (f *Formatter) formatDropFunction(w io.Writer, stmt *parser.DropFunctionStm
 
 		// Add ON CLUSTER if specified
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("on")+" "+f.keyword("cluster"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("on")+" "+f.keyword("cluster"), f.clusterName(*stmt.OnCluster))
 		}
 
 		if _, err := w.Write([]byte(strings.Join(parts, " "))); err != nil {

--- a/pkg/format/named_collection.go
+++ b/pkg/format/named_collection.go
@@ -30,7 +30,7 @@ func (f *Formatter) createNamedCollection(w io.Writer, stmt *parser.CreateNamedC
 	headerParts = append(headerParts, f.identifier(stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	headerParts = append(headerParts, f.keyword("AS"))
@@ -76,7 +76,7 @@ func (f *Formatter) alterNamedCollection(w io.Writer, stmt *parser.AlterNamedCol
 	headerParts = append(headerParts, f.identifier(stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	lines = append(lines, strings.Join(headerParts, " "))
@@ -105,7 +105,7 @@ func (f *Formatter) dropNamedCollection(w io.Writer, stmt *parser.DropNamedColle
 	headerParts = append(headerParts, f.identifier(stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	line := strings.Join(headerParts, " ") + ";"

--- a/pkg/format/role.go
+++ b/pkg/format/role.go
@@ -28,7 +28,7 @@ func (f *Formatter) createRole(w io.Writer, stmt *parser.CreateRoleStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// SETTINGS
@@ -59,7 +59,7 @@ func (f *Formatter) alterRole(w io.Writer, stmt *parser.AlterRoleStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// RENAME TO
@@ -164,7 +164,7 @@ func (f *Formatter) grant(w io.Writer, stmt *parser.GrantStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// ON target
@@ -213,7 +213,7 @@ func (f *Formatter) revoke(w io.Writer, stmt *parser.RevokeStmt) error {
 
 		// ON CLUSTER
 		if stmt.OnCluster != nil {
-			parts = append(parts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			parts = append(parts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		// ON target

--- a/pkg/format/table.go
+++ b/pkg/format/table.go
@@ -688,8 +688,7 @@ func (f *Formatter) formatModifyColumn(op *parser.ModifyColumnOperation) string 
 		parts = append(parts, f.formatExpression(&op.Default.Expression))
 	}
 	if op.Comment != nil {
-		parts = append(parts, f.keyword("COMMENT"))
-		parts = append(parts, "'"+*op.Comment+"'")
+		parts = append(parts, f.keyword("COMMENT"), *op.Comment)
 	}
 	if op.Codec != nil {
 		parts = append(parts, f.formatCodec(op.Codec))

--- a/pkg/format/table.go
+++ b/pkg/format/table.go
@@ -60,7 +60,7 @@ func (f *Formatter) buildCreateTableHeader(stmt *parser.CreateTableStmt) []strin
 	headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 	if stmt.OnCluster != nil {
-		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+		headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 	}
 
 	// Handle AS clause
@@ -291,7 +291,7 @@ func (f *Formatter) alterTable(w io.Writer, stmt *parser.AlterTableStmt) error {
 		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 		if stmt.OnCluster != nil {
-			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		lines = append(lines, strings.Join(headerParts, " "))
@@ -399,6 +399,11 @@ func (f *Formatter) formatColumn(col *parser.Column, alignWidth int) string {
 		parts = append(parts, f.formatExpression(&defaultClause.Expression))
 	}
 
+	// Comment — must precede CODEC per ClickHouse grammar
+	if comment := col.GetComment(); comment != nil {
+		parts = append(parts, f.keyword("COMMENT"), *comment)
+	}
+
 	// Codec
 	if codecClause := col.GetCodec(); codecClause != nil {
 		parts = append(parts, f.formatCodec(codecClause))
@@ -407,11 +412,6 @@ func (f *Formatter) formatColumn(col *parser.Column, alignWidth int) string {
 	// TTL
 	if ttlClause := col.GetTTL(); ttlClause != nil {
 		parts = append(parts, f.keyword("TTL"), f.formatExpression(&ttlClause.Expression))
-	}
-
-	// Comment
-	if comment := col.GetComment(); comment != nil {
-		parts = append(parts, f.keyword("COMMENT"), *comment)
 	}
 
 	// Trailing comments (inline with column)
@@ -443,6 +443,11 @@ func (f *Formatter) formatColumnWithoutComments(col *parser.Column, alignWidth i
 		parts = append(parts, f.formatExpression(&defaultClause.Expression))
 	}
 
+	// Comment — must precede CODEC per ClickHouse grammar
+	if comment := col.GetComment(); comment != nil {
+		parts = append(parts, f.keyword("COMMENT"), *comment)
+	}
+
 	// Codec
 	if codecClause := col.GetCodec(); codecClause != nil {
 		parts = append(parts, f.formatCodec(codecClause))
@@ -451,11 +456,6 @@ func (f *Formatter) formatColumnWithoutComments(col *parser.Column, alignWidth i
 	// TTL
 	if ttlClause := col.GetTTL(); ttlClause != nil {
 		parts = append(parts, f.keyword("TTL"), f.formatExpression(&ttlClause.Expression))
-	}
-
-	// Comment
-	if comment := col.GetComment(); comment != nil {
-		parts = append(parts, f.keyword("COMMENT"), *comment)
 	}
 
 	return strings.Join(parts, " ")
@@ -687,16 +687,16 @@ func (f *Formatter) formatModifyColumn(op *parser.ModifyColumnOperation) string 
 		parts = append(parts, f.keyword(op.Default.Type))
 		parts = append(parts, f.formatExpression(&op.Default.Expression))
 	}
+	if op.Comment != nil {
+		parts = append(parts, f.keyword("COMMENT"))
+		parts = append(parts, "'"+*op.Comment+"'")
+	}
 	if op.Codec != nil {
 		parts = append(parts, f.formatCodec(op.Codec))
 	}
 	if op.TTL != nil {
 		parts = append(parts, f.keyword("TTL"))
 		parts = append(parts, f.formatExpression(op.TTL))
-	}
-	if op.Comment != nil {
-		parts = append(parts, f.keyword("COMMENT"))
-		parts = append(parts, "'"+*op.Comment+"'")
 	}
 	return strings.Join(parts, " ")
 }

--- a/pkg/format/testdata/on_cluster_macro.in.sql
+++ b/pkg/format/testdata/on_cluster_macro.in.sql
@@ -1,0 +1,8 @@
+-- Cluster macro references must be preserved verbatim (no backtick quoting)
+CREATE TABLE steam_market_data ON CLUSTER '{cluster}' (ts DateTime64(6), price Int64) ENGINE = ReplicatedReplacingMergeTree() ORDER BY ts;
+
+-- Plain cluster names are backtick-quoted
+CREATE TABLE logs ON CLUSTER production (ts DateTime, msg String) ENGINE = MergeTree() ORDER BY ts;
+
+-- DROP with macro cluster
+DROP TABLE IF EXISTS events ON CLUSTER '{cluster}';

--- a/pkg/format/testdata/on_cluster_macro.sql
+++ b/pkg/format/testdata/on_cluster_macro.sql
@@ -1,0 +1,21 @@
+-- Cluster macro references must be preserved verbatim (no backtick quoting)
+
+CREATE TABLE `steam_market_data` ON CLUSTER '{cluster}' (
+    `ts`    DateTime64(6),
+    `price` Int64
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY `ts`;
+
+-- Plain cluster names are backtick-quoted
+
+CREATE TABLE `logs` ON CLUSTER `production` (
+    `ts`  DateTime,
+    `msg` String
+)
+ENGINE = MergeTree()
+ORDER BY `ts`;
+
+-- DROP with macro cluster
+
+DROP TABLE `events` ON CLUSTER '{cluster}';

--- a/pkg/format/testdata/table_operations.sql
+++ b/pkg/format/testdata/table_operations.sql
@@ -29,5 +29,5 @@ COMMENT 'Product catalog table';
 
 ALTER TABLE `analytics`.`events`
     ADD COLUMN `session_id` String DEFAULT '' AFTER `user_id`,
-    MODIFY COLUMN `metadata` String COMMENT ''Updated metadata column'',
+    MODIFY COLUMN `metadata` String COMMENT 'Updated metadata column',
     DROP COLUMN `version`;

--- a/pkg/format/view.go
+++ b/pkg/format/view.go
@@ -33,7 +33,7 @@ func (f *Formatter) createView(w io.Writer, stmt *parser.CreateViewStmt) error {
 		headerParts = append(headerParts, f.qualifiedName(stmt.Database, stmt.Name))
 
 		if stmt.OnCluster != nil {
-			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.identifier(*stmt.OnCluster))
+			headerParts = append(headerParts, f.keyword("ON CLUSTER"), f.clusterName(*stmt.OnCluster))
 		}
 
 		lines = append(lines, strings.Join(headerParts, " "))

--- a/pkg/parser/database.go
+++ b/pkg/parser/database.go
@@ -11,7 +11,7 @@ type (
 		Database    string          `parser:"'DATABASE'"`
 		IfNotExists bool            `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Name        string          `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Engine      *DatabaseEngine `parser:"@@?"`
 		Comment     *string         `parser:"('COMMENT' @String)?"`
 		TrailingCommentField
@@ -36,7 +36,7 @@ type (
 		Alter     string               `parser:"'ALTER'"`
 		Database  string               `parser:"'DATABASE'"`
 		Name      string               `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string              `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string              `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Action    *AlterDatabaseAction `parser:"@@"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -56,7 +56,7 @@ type (
 		IfNotExists bool            `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Name        string          `parser:"@(Ident | BacktickIdent)"`
 		Engine      *DatabaseEngine `parser:"@@?"`
-		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -69,7 +69,7 @@ type (
 		Database    string  `parser:"'DATABASE'"`
 		IfExists    bool    `parser:"@('IF' 'EXISTS')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently bool    `parser:"@'PERMANENTLY'?"`
 		Sync        bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
@@ -84,7 +84,7 @@ type (
 		Database  string  `parser:"'DATABASE'"`
 		IfExists  bool    `parser:"@('IF' 'EXISTS')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -97,7 +97,7 @@ type (
 		Rename    string            `parser:"'RENAME'"`
 		Database  string            `parser:"'DATABASE'"`
 		Renames   []*DatabaseRename `parser:"@@ (',' @@)*"`
-		OnCluster *string           `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string           `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}

--- a/pkg/parser/database_stmt_test.go
+++ b/pkg/parser/database_stmt_test.go
@@ -16,6 +16,7 @@ func TestCreateDatabase(t *testing.T) {
 		{name: "full_options", sql: "CREATE DATABASE IF NOT EXISTS full_db ON CLUSTER production ENGINE = Atomic COMMENT 'Full featured database';"},
 		{name: "with_backticks", sql: "CREATE DATABASE `user-database` ENGINE = Atomic;"},
 		{name: "backticks_full", sql: "CREATE DATABASE IF NOT EXISTS `order-db` ON CLUSTER `prod-cluster` COMMENT 'Database with special chars';"},
+		{name: "on_cluster_macro", sql: "CREATE DATABASE mydb ON CLUSTER '{cluster}' ENGINE = Atomic;"},
 	}
 
 	runStatementTests(t, "database/create", tests)

--- a/pkg/parser/dictionary.go
+++ b/pkg/parser/dictionary.go
@@ -27,7 +27,7 @@ type (
 		IfNotExists *string             `parser:"(@'IF' 'NOT' 'EXISTS')?"`
 		Database    *string             `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name        string              `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Columns     []*DictionaryColumn `parser:"'(' @@* ')'"`
 		Clauses     []DictionaryClause  `parser:"@@*"`
 		Comment     *string             `parser:"('COMMENT' @String)?"`
@@ -159,7 +159,7 @@ type (
 		IfNotExists *string `parser:"'ATTACH' 'DICTIONARY' (@'IF' 'NOT' 'EXISTS')?"`
 		Database    *string `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -172,7 +172,7 @@ type (
 		IfExists    *string `parser:"'DETACH' 'DICTIONARY' (@'IF' 'EXISTS')?"`
 		Database    *string `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently *string `parser:"(@'PERMANENTLY')?"`
 		Sync        *string `parser:"(@'SYNC')?"`
 		TrailingCommentField
@@ -187,7 +187,7 @@ type (
 		IfExists  *string `parser:"'DROP' 'DICTIONARY' (@'IF' 'EXISTS')?"`
 		Database  *string `parser:"((@(Ident | BacktickIdent) '.')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent))"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      *string `parser:"(@'SYNC')?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -198,7 +198,7 @@ type (
 	RenameDictionaryStmt struct {
 		LeadingCommentField
 		Renames   []*DictionaryRename `parser:"'RENAME' 'DICTIONARY' @@ (',' @@)*"`
-		OnCluster *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string             `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}

--- a/pkg/parser/function.go
+++ b/pkg/parser/function.go
@@ -7,7 +7,7 @@ type (
 	CreateFunctionStmt struct {
 		LeadingCommentField
 		Name       string           `parser:"'CREATE' 'FUNCTION' @(Ident | BacktickIdent)"`
-		OnCluster  *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Parameters []*FunctionParam `parser:"'AS' ( '(' (@@ (',' @@)*)? ')' | @@ )"`
 		Expression *Expression      `parser:"'->' @@"`
 		TrailingCommentField
@@ -20,7 +20,7 @@ type (
 		LeadingCommentField
 		IfExists  bool    `parser:"'DROP' 'FUNCTION' @('IF' 'EXISTS')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}

--- a/pkg/parser/named_collection.go
+++ b/pkg/parser/named_collection.go
@@ -22,7 +22,7 @@ type (
 		Collection     string                      `parser:"'COLLECTION'"`
 		IfNotExists    *string                     `parser:"(@'IF' 'NOT' 'EXISTS')?"`
 		Name           string                      `parser:"@(Ident | BacktickIdent)"`
-		OnCluster      *string                     `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster      *string                     `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		As             string                      `parser:"'AS'"`
 		Parameters     []*NamedCollectionParameter `parser:"@@*"`
 		GlobalOverride *NamedCollectionOverride    `parser:"@@?"`
@@ -41,7 +41,7 @@ type (
 		Collection string                          `parser:"'COLLECTION'"`
 		IfExists   *string                         `parser:"(@'IF' 'EXISTS')?"`
 		Name       string                          `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string                         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string                         `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Operations *AlterNamedCollectionOperations `parser:"@@? ';'"`
 	}
 
@@ -67,7 +67,7 @@ type (
 		Collection string  `parser:"'COLLECTION'"`
 		IfExists   *string `parser:"(@'IF' 'EXISTS')?"`
 		Name       string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Semicolon  string  `parser:"';'"`
 	}
 

--- a/pkg/parser/role.go
+++ b/pkg/parser/role.go
@@ -8,7 +8,7 @@ type (
 		OrReplace   bool          `parser:"'CREATE' (@'OR' 'REPLACE')? 'ROLE'"`
 		IfNotExists bool          `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Name        string        `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Settings    *RoleSettings `parser:"@@?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -20,7 +20,7 @@ type (
 		LeadingCommentField
 		IfExists  bool          `parser:"'ALTER' 'ROLE' @('IF' 'EXISTS')?"`
 		Name      string        `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		RenameTo  *string       `parser:"('RENAME' 'TO' @(Ident | BacktickIdent))?"`
 		Settings  *RoleSettings `parser:"@@?"`
 		TrailingCommentField
@@ -33,7 +33,7 @@ type (
 		LeadingCommentField
 		IfExists  bool     `parser:"'DROP' 'ROLE' @('IF' 'EXISTS')?"`
 		Names     []string `parser:"@(Ident | BacktickIdent) (',' @(Ident | BacktickIdent))*"`
-		OnCluster *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string  `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -65,7 +65,7 @@ type (
 	GrantStmt struct {
 		LeadingCommentField
 		Privileges  *PrivilegeList `parser:"'GRANT' @@"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		On          *GrantTarget   `parser:"('ON' @@)?"`
 		To          *GranteeList   `parser:"'TO' @@"`
 		WithGrant   bool           `parser:"@('WITH' 'GRANT' 'OPTION')?"`
@@ -82,7 +82,7 @@ type (
 		GrantOption bool           `parser:"'REVOKE' (@'GRANT' 'OPTION' 'FOR'"`
 		AdminOption bool           `parser:"| @'ADMIN' 'OPTION' 'FOR')?"`
 		Privileges  *PrivilegeList `parser:"@@"`
-		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		On          *GrantTarget   `parser:"('ON' @@)?"`
 		From        *GranteeList   `parser:"'FROM' @@"`
 		TrailingCommentField

--- a/pkg/parser/table.go
+++ b/pkg/parser/table.go
@@ -59,7 +59,7 @@ type (
 		IfNotExists       bool           `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Database          *string        `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name              string         `parser:"@(Ident | BacktickIdent)"`
-		OnCluster         *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster         *string        `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		AsTable           *TableSource   `parser:"('AS' @@)?"`
 		Elements          []TableElement `parser:"('(' @@ (',' @@)* ')')?"`
 		PreEngineComments []string       `parser:"@(Comment | MultilineComment)*"`
@@ -245,7 +245,7 @@ type (
 		IfNotExists bool    `parser:"('IF' 'NOT' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -260,7 +260,7 @@ type (
 		IfExists    bool    `parser:"('IF' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently bool    `parser:"@'PERMANENTLY'?"`
 		Sync        bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
@@ -277,7 +277,7 @@ type (
 		IfExists  bool    `parser:"('IF' 'EXISTS')?"`
 		Database  *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
@@ -291,7 +291,7 @@ type (
 		LeadingCommentField
 		Rename    string        `parser:"'RENAME' 'TABLE'"`
 		Renames   []TableRename `parser:"@@ (',' @@)*"`
-		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string       `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -326,7 +326,7 @@ type (
 		IfExists   bool                  `parser:"@('IF' 'EXISTS')?"`
 		Database   *string               `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name       string                `parser:"@(Ident | BacktickIdent)"`
-		OnCluster  *string               `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster  *string               `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Operations []AlterTableOperation `parser:"@@ (',' @@)*"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`

--- a/pkg/parser/table_stmt_test.go
+++ b/pkg/parser/table_stmt_test.go
@@ -53,6 +53,9 @@ func TestCreateTable(t *testing.T) {
 		SETTINGS index_granularity = 8192, merge_with_ttl_timeout = 3600
 		COMMENT 'User events table';`},
 
+		// Cluster macro references ('{cluster}', '{shard}', etc.)
+		{name: "on_cluster_macro", sql: `CREATE TABLE steam_market_data ON CLUSTER '{cluster}' (ts DateTime64(6), price Int64) ENGINE = ReplicatedReplacingMergeTree() ORDER BY ts;`},
+
 		// Backticks
 		{name: "with_backticks", sql: "CREATE TABLE `user-db`.`order-table` (`user-id` UInt64, `order-id` String, `order-date` Date, `select` String, `group` LowCardinality(String)) ENGINE = MergeTree() ORDER BY (`user-id`, `order-date`);"},
 
@@ -220,6 +223,7 @@ func TestDropTable(t *testing.T) {
 		{name: "basic", sql: `DROP TABLE users;`},
 		{name: "if_exists", sql: `DROP TABLE IF EXISTS temp_table;`},
 		{name: "on_cluster", sql: `DROP TABLE measurements ON CLUSTER production;`},
+		{name: "on_cluster_macro", sql: `DROP TABLE IF EXISTS events ON CLUSTER '{cluster}';`},
 		{name: "sync", sql: `DROP TABLE user_profiles SYNC;`},
 		{name: "full_options", sql: `DROP TABLE IF EXISTS analytics.old_events ON CLUSTER production SYNC;`},
 		{name: "with_backticks", sql: "DROP TABLE IF EXISTS `analytics-db`.`user-events` ON CLUSTER `prod-cluster`;"},

--- a/pkg/parser/testdata/database/create/on_cluster_macro.sql
+++ b/pkg/parser/testdata/database/create/on_cluster_macro.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE `mydb` ON CLUSTER '{cluster}' ENGINE = Atomic;

--- a/pkg/parser/testdata/table/create/full_options.sql
+++ b/pkg/parser/testdata/table/create/full_options.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE TABLE IF NOT EXISTS `analytics`.`events` ON CLUSTER `productio
     `tags`       Array(String) DEFAULT array(),
     `location`   Tuple(`lat` Float64, `lon` Float64),
     `settings`   Nested(`key` String, `value` String),
-    `temp_data`  String TTL `timestamp` + days(30) COMMENT 'Temporary data'
+    `temp_data`  String COMMENT 'Temporary data' TTL `timestamp` + days(30)
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/events', '{replica}')
 ORDER BY (`user_id`, `timestamp`)

--- a/pkg/parser/testdata/table/create/on_cluster_macro.sql
+++ b/pkg/parser/testdata/table/create/on_cluster_macro.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `steam_market_data` ON CLUSTER '{cluster}' (
+    `ts`    DateTime64(6),
+    `price` Int64
+)
+ENGINE = ReplicatedReplacingMergeTree()
+ORDER BY `ts`;

--- a/pkg/parser/testdata/table/drop/on_cluster_macro.sql
+++ b/pkg/parser/testdata/table/drop/on_cluster_macro.sql
@@ -1,0 +1,1 @@
+DROP TABLE `events` ON CLUSTER '{cluster}';

--- a/pkg/parser/testdata/view/create/on_cluster_macro.sql
+++ b/pkg/parser/testdata/view/create/on_cluster_macro.sql
@@ -1,0 +1,2 @@
+CREATE VIEW `v` ON CLUSTER '{cluster}'
+AS SELECT 1;

--- a/pkg/parser/view.go
+++ b/pkg/parser/view.go
@@ -28,7 +28,7 @@ type (
 		IfNotExists  bool             `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Database     *string          `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name         string           `parser:"@(Ident | BacktickIdent)"`
-		OnCluster    *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster    *string          `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		To           *ViewTableTarget `parser:"('TO' @@)?"`
 		Engine       *ViewEngine      `parser:"@@?"`
 		Populate     bool             `parser:"@'POPULATE'?"`
@@ -47,7 +47,7 @@ type (
 		IfNotExists bool    `parser:"@('IF' 'NOT' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`
 	}
@@ -62,7 +62,7 @@ type (
 		IfExists    bool    `parser:"@('IF' 'EXISTS')?"`
 		Database    *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name        string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster   *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Permanently bool    `parser:"@'PERMANENTLY'?"`
 		Sync        bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
@@ -79,7 +79,7 @@ type (
 		IfExists  bool    `parser:"@('IF' 'EXISTS')?"`
 		Database  *string `parser:"(@(Ident | BacktickIdent) '.')?"`
 		Name      string  `parser:"@(Ident | BacktickIdent)"`
-		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent))?"`
+		OnCluster *string `parser:"('ON' 'CLUSTER' @(Ident | BacktickIdent | String))?"`
 		Sync      bool    `parser:"@'SYNC'?"`
 		TrailingCommentField
 		Semicolon bool `parser:"';'"`

--- a/pkg/parser/view_stmt_test.go
+++ b/pkg/parser/view_stmt_test.go
@@ -9,6 +9,7 @@ func TestCreateView(t *testing.T) {
 		{name: "basic", sql: `CREATE VIEW analytics.daily_summary AS SELECT date, count(*) AS total FROM events GROUP BY date;`},
 		{name: "if_not_exists", sql: `CREATE VIEW IF NOT EXISTS users_view AS SELECT id, name FROM users WHERE active = 1;`},
 		{name: "on_cluster", sql: `CREATE VIEW stats_view ON CLUSTER production AS SELECT * FROM statistics;`},
+		{name: "on_cluster_macro", sql: `CREATE VIEW v ON CLUSTER '{cluster}' AS SELECT 1;`},
 		{name: "or_replace", sql: `CREATE OR REPLACE VIEW analytics.updated_view AS SELECT id, name, updated_at FROM users ORDER BY updated_at DESC;`},
 		{name: "with_backticks", sql: "CREATE VIEW `analytics-db`.`daily-summary` AS SELECT `order-date` AS `date`, count(*) AS `total-orders` FROM `orders-table` GROUP BY `order-date`;"},
 		{name: "with_window_functions", sql: `CREATE VIEW analytics.user_rankings AS SELECT user_id, name, score, row_number() OVER (ORDER BY score DESC) AS rank, rank() OVER (PARTITION BY category ORDER BY score DESC) AS category_rank FROM user_scores ORDER BY score DESC;`},

--- a/pkg/podman/detect.go
+++ b/pkg/podman/detect.go
@@ -1,0 +1,96 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	F "github.com/IBM/fp-go/v2/function"
+	O "github.com/IBM/fp-go/v2/option"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+)
+
+const housekeeperRuntimeEnv = "HOUSEKEEPER_RUNTIME"
+
+// AutoDetectResolver picks the right AddressResolver on first use and caches it.
+//
+// Detection order (highest to lowest priority):
+//  1. HOUSEKEEPER_RUNTIME=podman|docker — explicit override, always wins.
+//  2. CONTAINER_HOST env var — Podman sets this to its socket path.
+//  3. DOCKER_HOST env var — if it contains "podman", use Podman resolver.
+//  4. Well-known Podman socket paths on the filesystem.
+//  5. Default: Docker resolver.
+type AutoDetectResolver struct {
+	once     sync.Once
+	resolved docker.AddressResolver
+}
+
+// NewAutoDetectResolver creates an AddressResolver that detects the container runtime
+// automatically on first use.
+func NewAutoDetectResolver() docker.AddressResolver {
+	return &AutoDetectResolver{}
+}
+
+func (r *AutoDetectResolver) Resolve(ctx context.Context, client docker.DockerClient, containerName string) (*docker.ContainerAddress, error) {
+	r.once.Do(func() { r.resolved = detectResolver() })
+	return r.resolved.Resolve(ctx, client, containerName)
+}
+
+func detectResolver() docker.AddressResolver {
+	return F.Pipe4(
+		resolverFromRuntime(),
+		O.Alt(envToPodmanResolver("CONTAINER_HOST")),
+		O.Alt(envToPodmanResolver("DOCKER_HOST")),
+		O.Alt(func() O.Option[docker.AddressResolver] {
+			return O.MonadMap(
+				O.FromNonZero[bool]()(podmanSocketExists()),
+				F.Constant1[bool, docker.AddressResolver](&PodmanAddressResolver{}),
+			)
+		}),
+		O.GetOrElse(func() docker.AddressResolver { return &docker.DockerAddressResolver{} }),
+	)
+}
+
+func resolverFromRuntime() O.Option[docker.AddressResolver] {
+	switch strings.ToLower(os.Getenv(housekeeperRuntimeEnv)) {
+	case "podman":
+		return O.Some[docker.AddressResolver](&PodmanAddressResolver{})
+	case "docker":
+		return O.Some[docker.AddressResolver](&docker.DockerAddressResolver{})
+	default:
+		return O.None[docker.AddressResolver]()
+	}
+}
+
+// envToPodmanResolver returns a lazy probe for envVar: Some(PodmanAddressResolver) when
+// the value is a non-empty URI containing "podman", None otherwise.
+func envToPodmanResolver(envVar string) func() O.Option[docker.AddressResolver] {
+	return func() O.Option[docker.AddressResolver] {
+		return O.MonadMap(
+			O.FromPredicate(func(s string) bool {
+				return s != "" && strings.Contains(strings.ToLower(s), "podman")
+			})(os.Getenv(envVar)),
+			func(_ string) docker.AddressResolver { return &PodmanAddressResolver{} },
+		)
+	}
+}
+
+// podmanSocketExists probes the well-known rootful, rootless, and XDG_RUNTIME_DIR
+// socket paths for a live Podman socket.
+func podmanSocketExists() bool {
+	candidates := []string{
+		fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid()),
+		"/run/podman/podman.sock",
+	}
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		candidates = append(candidates, xdg+"/podman/podman.sock")
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/podman/detect_test.go
+++ b/pkg/podman/detect_test.go
@@ -1,0 +1,190 @@
+package podman_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+	"github.com/pseudomuto/housekeeper/pkg/podman"
+	"github.com/stretchr/testify/require"
+)
+
+// skipIfPodmanSocket skips the test when a Podman socket exists on the filesystem.
+// The socket probe in detectResolver() has higher priority than the default Docker
+// fallback, so tests that expect DockerAddressResolver would fail on Podman hosts.
+func skipIfPodmanSocket(t *testing.T) {
+	t.Helper()
+	candidates := []string{
+		fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid()),
+		"/run/podman/podman.sock",
+	}
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		candidates = append(candidates, xdg+"/podman/podman.sock")
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			t.Skipf("Podman socket found at %s — socket probe supersedes DOCKER_HOST fallback on this host", p)
+		}
+	}
+}
+
+// podmanInspect returns an InspectResponse with a bridge IP, mimicking Podman rootless.
+func podmanInspect(ip string) container.InspectResponse {
+	return container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			DefaultNetworkSettings: container.DefaultNetworkSettings{
+				IPAddress: ip,
+			},
+		},
+	}
+}
+
+// dockerInspect returns an InspectResponse with port bindings, mimicking Docker Engine.
+func dockerInspect(nativeHost, httpHost string) container.InspectResponse {
+	return container.InspectResponse{
+		NetworkSettings: &container.NetworkSettings{
+			NetworkSettingsBase: container.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					nat.Port("9000/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: nativeHost}},
+					nat.Port("8123/tcp"): []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: httpHost}},
+				},
+			},
+		},
+	}
+}
+
+func TestAutoDetectResolver_PodmanRuntime_UsesBridgeIP(t *testing.T) {
+	// HOUSEKEEPER_RUNTIME=podman must select PodmanAddressResolver, which reads the
+	// container's direct bridge IP (not the mapped host port).
+	t.Setenv("HOUSEKEEPER_RUNTIME", "podman")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.88.0.5"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.5", addr.Host)
+	require.Equal(t, docker.DefaultClickHousePort, addr.NativePort)
+	require.Equal(t, docker.DefaultClickHouseHTTPPort, addr.HTTPPort)
+}
+
+func TestAutoDetectResolver_DockerRuntime_UsesPortBindings(t *testing.T) {
+	// HOUSEKEEPER_RUNTIME=docker must select DockerAddressResolver, which reads
+	// mapped host ports and returns localhost:<hostPort>.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "docker")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return dockerInspect("54321", "54322"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "localhost", addr.Host)
+	require.Equal(t, 54321, addr.NativePort)
+	require.Equal(t, 54322, addr.HTTPPort)
+}
+
+func TestAutoDetectResolver_ContainerHostPodmanSocket_UsesBridgeIP(t *testing.T) {
+	// CONTAINER_HOST pointing to a Podman socket activates the Podman resolver.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "")
+	t.Setenv("CONTAINER_HOST", "unix:///run/user/1000/podman/podman.sock")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.89.0.2"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.89.0.2", addr.Host)
+}
+
+func TestAutoDetectResolver_DockerHostPodmanSocket_UsesBridgeIP(t *testing.T) {
+	// DOCKER_HOST containing "podman" activates the Podman resolver.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "unix:///run/user/1000/podman/podman.sock")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.90.0.3"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.90.0.3", addr.Host)
+}
+
+func TestAutoDetectResolver_DockerSocket_UsesPortBindings(t *testing.T) {
+	// A Docker socket URI in DOCKER_HOST does NOT activate Podman — falls back to Docker.
+	// Skip on hosts where a Podman socket exists: the socket probe fires before the default
+	// fallback and would select PodmanAddressResolver regardless of DOCKER_HOST.
+	skipIfPodmanSocket(t)
+	t.Setenv("HOUSEKEEPER_RUNTIME", "")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "unix:///var/run/docker.sock")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return dockerInspect("32768", "32769"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "ch-test")
+
+	require.NoError(t, err)
+	require.Equal(t, "localhost", addr.Host)
+	require.Equal(t, 32768, addr.NativePort)
+}
+
+func TestAutoDetectResolver_CachesResult(t *testing.T) {
+	// sync.Once guarantees detection fires exactly once; calls after the first
+	// must reuse the cached resolver — verified by flipping the env var midway.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "podman")
+	t.Setenv("CONTAINER_HOST", "")
+	t.Setenv("DOCKER_HOST", "")
+
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return podmanInspect("10.88.0.9"), nil
+		},
+	}
+
+	resolver := podman.NewAutoDetectResolver()
+
+	// First call triggers detection (podman selected).
+	addr1, err := resolver.Resolve(context.Background(), cli, "ch-test")
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.9", addr1.Host)
+
+	// Switch env var — second call must still use the cached Podman resolver.
+	t.Setenv("HOUSEKEEPER_RUNTIME", "docker")
+	addr2, err := resolver.Resolve(context.Background(), cli, "ch-test")
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.9", addr2.Host, "cached resolver must ignore env change")
+}

--- a/pkg/podman/doc.go
+++ b/pkg/podman/doc.go
@@ -1,0 +1,42 @@
+// Package podman provides AddressResolver implementations for Podman container runtimes.
+//
+// Podman exposes a Docker-compatible REST API (the "compat" API), but its networking
+// model differs from Docker in important ways for rootless containers:
+//
+//   - Docker maps container ports to random host ports on the loopback interface.
+//     Clients connect to localhost:<randomHostPort>.
+//
+//   - Podman rootless uses the slirp4netns or pasta user-space networking stack.
+//     The compat API reports port bindings in the inspect response, but those bindings
+//     may not be reachable on localhost from within a container or a different network
+//     namespace. The container is reachable directly via its bridge IP address.
+//
+// This package provides two implementations of docker.AddressResolver:
+//
+//   - PodmanAddressResolver: always uses the container's bridge IP + container port.
+//     Use this when you know you are running under Podman.
+//
+//   - AutoDetectResolver: inspects the environment at runtime (CONTAINER_HOST /
+//     DOCKER_HOST env vars, Podman socket paths, HOUSEKEEPER_RUNTIME override) and
+//     selects the appropriate resolver transparently.
+//
+// # Usage
+//
+//	import (
+//		"github.com/docker/docker/client"
+//		"github.com/pseudomuto/housekeeper/pkg/docker"
+//		"github.com/pseudomuto/housekeeper/pkg/podman"
+//	)
+//
+//	cli, _ := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+//
+//	// Explicit Podman resolver:
+//	container, _ := docker.NewWithOptions(cli, docker.DockerOptions{
+//		AddressResolver: podman.NewPodmanAddressResolver(),
+//	})
+//
+//	// Auto-detect at runtime (recommended for tools that support both):
+//	container, _ := docker.NewWithOptions(cli, docker.DockerOptions{
+//		AddressResolver: podman.NewAutoDetectResolver(),
+//	})
+package podman

--- a/pkg/podman/resolver.go
+++ b/pkg/podman/resolver.go
@@ -1,0 +1,67 @@
+package podman
+
+import (
+	"context"
+
+	O "github.com/IBM/fp-go/v2/option"
+	F "github.com/IBM/fp-go/v2/function"
+	R "github.com/IBM/fp-go/v2/result"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/pkg/errors"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+)
+
+// PodmanAddressResolver implements docker.AddressResolver for Podman environments.
+//
+// Under Podman rootless (slirp4netns / pasta), port bindings in the compat API are
+// not reliably reachable on localhost from the host network namespace. The container
+// is reachable via its direct bridge IP, which Podman populates even for rootless
+// containers.
+type PodmanAddressResolver struct{}
+
+// NewPodmanAddressResolver creates an AddressResolver for Podman environments.
+func NewPodmanAddressResolver() docker.AddressResolver {
+	return &PodmanAddressResolver{}
+}
+
+func (r *PodmanAddressResolver) Resolve(ctx context.Context, client docker.DockerClient, containerName string) (*docker.ContainerAddress, error) {
+	inspect, err := client.ContainerInspect(ctx, containerName)
+	return R.UnwrapError(F.Pipe2(
+		R.TryCatchError(inspect, errors.Wrapf(err, "failed to inspect container %q", containerName)),
+		R.Chain(func(inspect dockercontainer.InspectResponse) R.Result[string] {
+			return R.FromOption[string](func() error {
+				return errors.Errorf(
+					"container %q has no assigned IP address; "+
+						"ensure the container is running and attached to a bridge network",
+					containerName,
+				)
+			})(resolveContainerIP(inspect))
+		}),
+		R.Map(func(ip string) *docker.ContainerAddress {
+			return &docker.ContainerAddress{
+				Host:       ip,
+				NativePort: docker.DefaultClickHousePort,
+				HTTPPort:   docker.DefaultClickHouseHTTPPort,
+			}
+		}),
+	))
+}
+
+// resolveContainerIP tries NetworkSettings.IPAddress first, then falls back to the
+// first non-empty per-network entry (Podman CNI / netavark assigns IPs per network).
+// Extracted as a pure function so it can be tested without a Docker client.
+func resolveContainerIP(inspect dockercontainer.InspectResponse) O.Option[string] {
+	ns := inspect.NetworkSettings
+	if ns == nil {
+		return O.None[string]()
+	}
+	primary := O.FromPredicate[string](func(s string) bool { return s != "" })(ns.IPAddress)
+	return O.MonadAlt(primary, func() O.Option[string] {
+		for _, n := range ns.Networks {
+			if n != nil && n.IPAddress != "" {
+				return O.Some(n.IPAddress)
+			}
+		}
+		return O.None[string]()
+	})
+}

--- a/pkg/podman/resolver_test.go
+++ b/pkg/podman/resolver_test.go
@@ -1,0 +1,116 @@
+package podman_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/network"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pseudomuto/housekeeper/pkg/docker"
+	"github.com/pseudomuto/housekeeper/pkg/podman"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDockerClient is a minimal stub that satisfies docker.DockerClient.
+// Only ContainerInspect is exercised in resolver tests; all other methods panic.
+type mockDockerClient struct {
+	inspectFn func(ctx context.Context, name string) (container.InspectResponse, error)
+}
+
+func (m *mockDockerClient) ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error) {
+	return m.inspectFn(ctx, containerID)
+}
+
+func (m *mockDockerClient) ImagePull(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerCreate(_ context.Context, _ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ *v1.Platform, _ string) (container.CreateResponse, error) {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerStart(_ context.Context, _ string, _ container.StartOptions) error {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerList(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerStop(_ context.Context, _ string, _ container.StopOptions) error {
+	panic("not implemented")
+}
+func (m *mockDockerClient) ContainerRemove(_ context.Context, _ string, _ container.RemoveOptions) error {
+	panic("not implemented")
+}
+
+func TestPodmanAddressResolver_NetworkSettingsIP(t *testing.T) {
+	// Simulate a container with a bridge IP in NetworkSettings.IPAddress (most common case).
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return container.InspectResponse{
+				NetworkSettings: &container.NetworkSettings{
+					DefaultNetworkSettings: container.DefaultNetworkSettings{
+						IPAddress: "10.88.0.5",
+					},
+				},
+			}, nil
+		},
+	}
+
+	resolver := podman.NewPodmanAddressResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "test-container")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.88.0.5", addr.Host)
+	require.Equal(t, docker.DefaultClickHousePort, addr.NativePort)
+	require.Equal(t, docker.DefaultClickHouseHTTPPort, addr.HTTPPort)
+}
+
+func TestPodmanAddressResolver_FallbackToNetworkIP(t *testing.T) {
+	// Simulate a container where NetworkSettings.IPAddress is empty (Podman CNI/netavark)
+	// but the per-network entry has an IP.
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return container.InspectResponse{
+				NetworkSettings: &container.NetworkSettings{
+					DefaultNetworkSettings: container.DefaultNetworkSettings{
+						IPAddress: "", // empty — not on default bridge
+					},
+					Networks: map[string]*network.EndpointSettings{
+						"podman": {
+							IPAddress: "10.89.0.3",
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	resolver := podman.NewPodmanAddressResolver()
+	addr, err := resolver.Resolve(context.Background(), cli, "test-container")
+
+	require.NoError(t, err)
+	require.Equal(t, "10.89.0.3", addr.Host)
+}
+
+func TestPodmanAddressResolver_NoIP_ReturnsError(t *testing.T) {
+	// Simulate a container with no IP at all — resolver must return a descriptive error.
+	cli := &mockDockerClient{
+		inspectFn: func(_ context.Context, _ string) (container.InspectResponse, error) {
+			return container.InspectResponse{
+				NetworkSettings: &container.NetworkSettings{
+					DefaultNetworkSettings: container.DefaultNetworkSettings{
+						IPAddress: "",
+					},
+				},
+			}, nil
+		},
+	}
+
+	resolver := podman.NewPodmanAddressResolver()
+	_, err := resolver.Resolve(context.Background(), cli, "no-ip-container")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no-ip-container",
+		"error should identify the container by name")
+}

--- a/pkg/schema/compile.go
+++ b/pkg/schema/compile.go
@@ -1,65 +1,92 @@
 package schema
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
+	A "github.com/IBM/fp-go/v2/array"
+	F "github.com/IBM/fp-go/v2/function"
+	IOE "github.com/IBM/fp-go/v2/ioeither"
+	file "github.com/IBM/fp-go/v2/ioeither/file"
+	R "github.com/IBM/fp-go/v2/result"
 )
 
-// Compile recursively compiles a schema file and its imports. It processes import directives (lines
-// starting with "-- housekeeper:import") and includes the referenced files' contents in the output.
-// Import paths are resolved relative to the current file's directory.
+var readDir = IOE.Eitherize1(os.ReadDir)
+
+// Compile recursively compiles a schema entrypoint and writes the result to w.
 //
-// Example:
+// The entrypoint may be:
+//   - A single .sql file, optionally containing -- housekeeper:import directives
+//   - A directory, in which case all *.sql files are compiled in alphabetical order
 //
-//	var buf bytes.Buffer
-//	err := schema.Compile("db/main.sql", &buf)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
+// Import paths inside a file are resolved relative to that file's directory:
 //
-//	// The compiled schema is now in buf
-//	compiledSQL := buf.String()
-//
-//	// Parse the compiled schema
-//	sql, err := parser.ParseString(compiledSQL)
-//	if err != nil {
-//		log.Fatal(err)
-//	}
+//	-- housekeeper:import tables/users.sql
 func Compile(path string, w io.Writer) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read file %s", path)
-	}
-	defer func() { _ = f.Close() }()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "-- housekeeper:import") {
-			parts := strings.Split(line, " ")
-			importPath := parts[len(parts)-1]
-
-			// Resolve import path relative to current file's directory
-			if !filepath.IsAbs(importPath) {
-				dir := filepath.Dir(path)
-				importPath = filepath.Join(dir, importPath)
+	return R.ToError(F.Pipe1(
+		file.Stat(path)(),
+		R.Chain(func(info os.FileInfo) R.Result[struct{}] {
+			if info.IsDir() {
+				return R.TryCatchError(struct{}{}, compileDir(path, w))
 			}
+			return R.TryCatchError(struct{}{}, compileFile(path, w))
+		}),
+	))
+}
 
-			if err := Compile(importPath, w); err != nil {
-				return err
-			}
+// compileDir compiles all *.sql files in dir in alphabetical order.
+// Sub-directories are ignored; use -- housekeeper:import for explicit cross-directory includes.
+func compileDir(dir string, w io.Writer) error {
+	return R.ToError(F.Pipe1(
+		readDir(dir)(),
+		R.Chain(func(entries []os.DirEntry) R.Result[struct{}] {
+			sqlFiles := A.Filter(func(e os.DirEntry) bool {
+				return !e.IsDir() && strings.HasSuffix(e.Name(), ".sql")
+			})(entries)
+			return F.Pipe1(
+				R.TraverseArray(func(e os.DirEntry) R.Result[struct{}] {
+					return R.TryCatchError(struct{}{}, compileFile(filepath.Join(dir, e.Name()), w))
+				})(sqlFiles),
+				R.Map(F.Constant1[[]struct{}, struct{}](struct{}{})),
+			)
+		}),
+	))
+}
 
-			continue
+// compileFile reads path, processes -- housekeeper:import directives recursively,
+// and writes all non-directive lines to w.
+func compileFile(path string, w io.Writer) error {
+	return R.ToError(F.Pipe2(
+		file.ReadAll(file.Open(path))(),
+		R.Map(func(b []byte) []string {
+			return strings.Split(strings.TrimRight(string(b), "\r\n"), "\n")
+		}),
+		R.Chain(func(lines []string) R.Result[struct{}] {
+			return F.Pipe1(
+				R.TraverseArray(processLine(path, w))(lines),
+				R.Map(F.Constant1[[]struct{}, struct{}](struct{}{})),
+			)
+		}),
+	))
+}
+
+// processLine returns a function that either emits line to w (for regular SQL lines) or
+// recursively compiles the referenced file (for -- housekeeper:import directives).
+// Import paths are resolved relative to the directory containing path.
+func processLine(path string, w io.Writer) func(string) R.Result[struct{}] {
+	return func(line string) R.Result[struct{}] {
+		if !strings.HasPrefix(line, "-- housekeeper:import") {
+			fmt.Fprintln(w, line)
+			return R.Of(struct{}{})
 		}
-
-		fmt.Fprintln(w, line)
+		parts := strings.Split(line, " ")
+		importPath := parts[len(parts)-1]
+		if !filepath.IsAbs(importPath) {
+			importPath = filepath.Join(filepath.Dir(path), importPath)
+		}
+		return R.TryCatchError(struct{}{}, Compile(importPath, w))
 	}
-
-	return errors.Wrapf(scanner.Err(), "failed scanning %s", path)
 }

--- a/pkg/schema/compile_test.go
+++ b/pkg/schema/compile_test.go
@@ -138,7 +138,7 @@ CREATE TABLE test_db.users (id UInt64) ENGINE = MergeTree() ORDER BY id;`
 		var buf bytes.Buffer
 		err := schema.Compile("non-existent-file.sql", &buf)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to read file")
+		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("returns error for non-existent import", func(t *testing.T) {
@@ -155,7 +155,7 @@ CREATE TABLE test_db.users (id UInt64) ENGINE = MergeTree() ORDER BY id;`
 		var buf bytes.Buffer
 		err = schema.Compile(schemaFile, &buf)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to read file")
+		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("handles absolute import paths", func(t *testing.T) {
@@ -181,6 +181,41 @@ CREATE TABLE test_db.users (id UInt64) ENGINE = MergeTree() ORDER BY id;`
 		compiled := buf.String()
 		require.Contains(t, compiled, "CREATE DATABASE test_db")
 		require.Contains(t, compiled, "CREATE TABLE test_db.imported_table")
+	})
+
+	t.Run("compiles directory entrypoint in alphabetical order", func(t *testing.T) {
+		schemaDir := t.TempDir()
+
+		err := os.WriteFile(filepath.Join(schemaDir, "02_tables.sql"), []byte(
+			"CREATE TABLE app.users (id UInt64) ENGINE = MergeTree() ORDER BY id;",
+		), consts.ModeFile)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(schemaDir, "01_databases.sql"), []byte(
+			"CREATE DATABASE app ENGINE = Atomic;",
+		), consts.ModeFile)
+		require.NoError(t, err)
+
+		// Non-.sql files should be ignored
+		err = os.WriteFile(filepath.Join(schemaDir, "README.md"), []byte("docs"), consts.ModeFile)
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = schema.Compile(schemaDir, &buf)
+		require.NoError(t, err)
+
+		compiled := buf.String()
+		require.Contains(t, compiled, "CREATE DATABASE app")
+		require.Contains(t, compiled, "CREATE TABLE app.users")
+		// 01_ must appear before 02_ (alphabetical order)
+		require.Less(t, strings.Index(compiled, "CREATE DATABASE"), strings.Index(compiled, "CREATE TABLE"))
+	})
+
+	t.Run("returns error for non-existent directory", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := schema.Compile("/nonexistent-dir", &buf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
 	t.Run("preserves line structure", func(t *testing.T) {

--- a/pkg/schema/dictionary.go
+++ b/pkg/schema/dictionary.go
@@ -760,9 +760,9 @@ func buildDictionaryHeader(parts []string, stmt *parser.CreateDictionaryStmt, us
 		parts = append(parts, stmt.Name)
 	}
 
-	// ON CLUSTER
+	// ON CLUSTER — use FormatClusterName so macro refs like '{cluster}' are emitted verbatim
 	if stmt.OnCluster != nil {
-		parts = append(parts, "ON CLUSTER", *stmt.OnCluster)
+		parts = append(parts, "ON CLUSTER", utils.FormatClusterName(*stmt.OnCluster))
 	}
 
 	return parts

--- a/pkg/schema/table.go
+++ b/pkg/schema/table.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strings"
 
+	A "github.com/IBM/fp-go/v2/array"
+	O "github.com/IBM/fp-go/v2/option"
 	"github.com/pseudomuto/housekeeper/pkg/compare"
 	"github.com/pseudomuto/housekeeper/pkg/consts"
 	"github.com/pseudomuto/housekeeper/pkg/parser"
@@ -194,6 +196,20 @@ func compareTables(current, target *parser.SQL) ([]*TableDiff, error) {
 	targetTables, err := extractTablesFromSQL(target)
 	if err != nil {
 		return nil, err
+	}
+
+	// Normalise the cluster name in all current (live-DB) tables to match the
+	// target schema's cluster convention. ClickHouse expands macros like
+	// '{cluster}' to their concrete values (e.g. 'default') when reporting
+	// SHOW CREATE TABLE, so the current state always holds the concrete name.
+	// Without this step, ALTER/DROP/RENAME migrations would hard-code the
+	// cluster name instead of preserving the portable macro syntax.
+	if sc := inferSchemaCluster(targetTables); sc != "" {
+		for _, t := range currentTables {
+			if t.Cluster != "" {
+				t.Cluster = sc
+			}
+		}
 	}
 
 	// Pre-allocate diffs slice with estimated capacity
@@ -556,9 +572,36 @@ func findRenamedTable(targetTable *TableInfo, currentTables, targetTables map[st
 	return ""
 }
 
-// tablesEqual compares two tables for equality
-func tablesEqual(a, b *TableInfo) bool {
-	return a.Equal(b)
+// inferSchemaCluster returns the authoritative cluster name from the target schema.
+// Priority:
+//  1. Any server macro (e.g. '{cluster}') — portable across clusters.
+//  2. Unanimous plain name — all clustered tables agree on the same value.
+//  3. "" — mixed names or no clustered tables; conservative, avoids incorrect rewrites.
+//
+// The result is applied to live-DB tables before diff generation so that ALTER / DROP /
+// RENAME migrations emit the same cluster syntax as the desired schema instead of the
+// concrete name ClickHouse reports after macro expansion.
+func inferSchemaCluster(tables map[string]*TableInfo) string {
+	clusters := make([]string, 0, len(tables))
+	for _, t := range tables {
+		if t.Cluster != "" {
+			clusters = append(clusters, t.Cluster)
+		}
+	}
+	return O.MonadGetOrElse(
+		O.MonadAlt(
+			A.FindFirst(utils.IsClickHouseMacro)(clusters),
+			func() O.Option[string] {
+				return O.MonadChain(A.Head(clusters), func(first string) O.Option[string] {
+					if A.Any(func(c string) bool { return c != first })(clusters) {
+						return O.None[string]()
+					}
+					return O.Some(first)
+				})
+			},
+		),
+		func() string { return "" },
+	)
 }
 
 // tablesEqualIgnoringName compares two tables for equality ignoring name and database
@@ -683,11 +726,13 @@ func formatQualifiedTableName(database, name string) string {
 	return name
 }
 
-// writeOnClusterClause writes an ON CLUSTER clause if cluster is specified
+// writeOnClusterClause writes an ON CLUSTER clause if cluster is specified.
+// Uses FormatClusterName so that macro references (e.g. '{cluster}') are emitted verbatim
+// and plain names are backtick-quoted for safety.
 func writeOnClusterClause(sql *strings.Builder, cluster string) {
 	if cluster != "" {
 		sql.WriteString(" ON CLUSTER ")
-		sql.WriteString(cluster)
+		sql.WriteString(utils.FormatClusterName(cluster))
 	}
 }
 
@@ -913,7 +958,7 @@ func handleTableExists(tableName string, currentTable, targetTable *TableInfo) (
 	// For comparison purposes, flatten the target table to match ClickHouse's internal representation
 	// Current table is already flattened by ClickHouse, but target table may have Nested syntax
 	flattenedTargetTable := FlattenNestedColumns(targetTable)
-	if tablesEqual(currentTable, flattenedTargetTable) {
+	if currentTable.Equal(flattenedTargetTable) {
 		return nil, nil
 	}
 

--- a/pkg/schema/table_test.go
+++ b/pkg/schema/table_test.go
@@ -108,6 +108,152 @@ func TestTableInfoEqual(t *testing.T) {
 	require.False(t, result, "Tables with different ReplicatedMergeTree parameters should not be equal")
 }
 
+func TestInferSchemaCluster(t *testing.T) {
+	cases := []struct {
+		name     string
+		tables   map[string]*TableInfo
+		expected string
+	}{
+		{
+			name: "macro cluster is authoritative",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "'{cluster}'"},
+				"sales":  {Cluster: "'{cluster}'"},
+			},
+			expected: "'{cluster}'",
+		},
+		{
+			name: "macro wins over plain names in the same map",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "default"},
+				"sales":  {Cluster: "'{cluster}'"},
+			},
+			expected: "'{cluster}'",
+		},
+		{
+			name: "unanimous plain name is returned",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "default"},
+				"sales":  {Cluster: "default"},
+			},
+			expected: "default",
+		},
+		{
+			name: "mixed plain names — no normalisation",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "cluster-a"},
+				"sales":  {Cluster: "cluster-b"},
+			},
+			expected: "",
+		},
+		{
+			name: "no clustered tables — no normalisation",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: ""},
+			},
+			expected: "",
+		},
+		{
+			name:     "empty map",
+			tables:   map[string]*TableInfo{},
+			expected: "",
+		},
+		{
+			name: "shard macro is also accepted",
+			tables: map[string]*TableInfo{
+				"metrics": {Cluster: "'{shard}'"},
+			},
+			expected: "'{shard}'",
+		},
+		{
+			name: "plain-quoted string without braces is NOT a macro",
+			tables: map[string]*TableInfo{
+				"events": {Cluster: "'plain-string'"},
+			},
+			expected: "'plain-string'", // treated as unanimous plain name
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inferSchemaCluster(tc.tables)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestCompareTables_ClusterNormalisation verifies that ALTER/DROP/RENAME
+// migrations use the target schema's cluster macro ('{cluster}') rather than
+// the concrete cluster name that ClickHouse reports after macro expansion.
+func TestCompareTables_ClusterNormalisation(t *testing.T) {
+	// current = live DB state after applying migrations; ClickHouse has expanded
+	// '{cluster}' → 'default' in SHOW CREATE TABLE output.
+	current, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER default (
+			id UInt64, name String
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	// target = desired schema with the portable macro syntax.
+	target, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER '{cluster}' (
+			id UInt64, name String, ts DateTime
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	diffs, err := compareTables(current, target)
+	require.NoError(t, err)
+	require.Len(t, diffs, 1)
+
+	// The ALTER TABLE migration must use the macro, not the concrete name.
+	require.Contains(t, diffs[0].UpSQL, "'{cluster}'",
+		"ALTER TABLE UpSQL must use the macro cluster syntax")
+	require.NotContains(t, diffs[0].UpSQL, "`default`",
+		"ALTER TABLE UpSQL must not hard-code the concrete cluster name")
+}
+
+// TestCompareTables_DropClusterNormalisation verifies that DROP TABLE
+// migrations generated for orphaned tables also use the target schema's cluster
+// macro rather than the concrete cluster name from the live DB.
+func TestCompareTables_DropClusterNormalisation(t *testing.T) {
+	// current contains a table that no longer exists in the desired schema.
+	current, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER default (
+			id UInt64
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+		CREATE TABLE orphan ON CLUSTER default (
+			id UInt64
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	// target keeps only 'events', using the portable macro.
+	target, err := parser.ParseString(`
+		CREATE TABLE events ON CLUSTER '{cluster}' (
+			id UInt64
+		) ENGINE = ReplicatedMergeTree() ORDER BY id;
+	`)
+	require.NoError(t, err)
+
+	diffs, err := compareTables(current, target)
+	require.NoError(t, err)
+
+	var dropDiff *TableDiff
+	for _, d := range diffs {
+		if d.Type == string(TableDiffDrop) {
+			dropDiff = d
+			break
+		}
+	}
+	require.NotNil(t, dropDiff, "expected a DROP diff for orphan table")
+	require.Contains(t, dropDiff.UpSQL, "'{cluster}'",
+		"DROP TABLE UpSQL must use the macro cluster syntax")
+	require.NotContains(t, dropDiff.UpSQL, "`default`",
+		"DROP TABLE UpSQL must not hard-code the concrete cluster name")
+}
+
 // Helper function to create string pointers
 func stringPtr(s string) *string {
 	return &s

--- a/pkg/utils/identifier.go
+++ b/pkg/utils/identifier.go
@@ -1,6 +1,17 @@
 package utils
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+// chMacroRe matches ClickHouse server-side macro references as stored by the
+// participle lexer. The lexer emits String tokens with their surrounding single
+// quotes intact, so '{cluster}' is stored as the Go string "'{cluster}'".
+//
+// Pattern: opening quote, opening brace, a valid ClickHouse identifier
+// ([A-Za-z_][A-Za-z0-9_]*), closing brace, closing quote.
+var chMacroRe = regexp.MustCompile(`^'\{[A-Za-z_][A-Za-z0-9_]*\}'$`)
 
 // BacktickIdentifier adds backticks around an identifier, handling nested identifiers.
 // It properly handles database.table.column style identifiers by backticking each part.
@@ -93,6 +104,73 @@ func BacktickQualifiedName(database *string, name string) string {
 //   - "" -> false
 func IsBackticked(s string) bool {
 	return len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' && !strings.Contains(s[1:len(s)-1], "`")
+}
+
+// IsClusterMacro reports whether a cluster name is a ClickHouse server macro reference.
+//
+// ClickHouse macros use single-quoted braces in ON CLUSTER clauses, e.g. '{cluster}',
+// '{shard}'. These are expanded at query execution time from the server's macros config
+// (<macros><cluster>…</cluster></macros>). They must be preserved verbatim in DDL so that
+// migrations are portable across clusters with different names.
+//
+// The parser stores the raw lexer token value for String tokens, which includes the
+// surrounding single quotes, so '{cluster}' is stored as the Go string "'{cluster}'".
+//
+// Examples:
+//
+//	IsClusterMacro("'{cluster}'") → true
+//	IsClusterMacro("'{shard}'")   → true
+//	IsClusterMacro("default")     → false
+//	IsClusterMacro("")            → false
+func IsClusterMacro(s string) bool {
+	return len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\''
+}
+
+// IsClickHouseMacro reports whether s is a ClickHouse server macro reference
+// of the form '{identifier}' (single-quoted curly-brace expression).
+//
+// This is stricter than IsClusterMacro: it requires the inner content to be a
+// valid identifier wrapped in curly braces, matching the ClickHouse <macros>
+// config substitution syntax. Use this when you need to distinguish a genuine
+// server macro (suitable for cross-cluster portability) from an arbitrary
+// single-quoted cluster name.
+//
+// Examples:
+//
+//	IsClickHouseMacro("'{cluster}'")      → true
+//	IsClickHouseMacro("'{shard}'")        → true
+//	IsClickHouseMacro("'{replica}'")      → true
+//	IsClickHouseMacro("'plain-string'")   → false  (no braces)
+//	IsClickHouseMacro("default")          → false  (not quoted)
+//	IsClickHouseMacro("")                 → false
+func IsClickHouseMacro(s string) bool {
+	return chMacroRe.MatchString(s)
+}
+
+// FormatClusterName formats a cluster name for use in SQL DDL output.
+//
+// This is the single, canonical place where the macro-vs-identifier distinction is
+// handled for ON CLUSTER clauses. It is used by the formatter, SQLBuilder, and the
+// schema DDL generators so that macro syntax is preserved end-to-end.
+//
+// - Macro references (e.g. "'{cluster}'") are returned as-is — the single quotes are
+//   part of the ClickHouse syntax and must not be wrapped in backticks.
+// - Plain identifiers (e.g. "default", "my-cluster") are backtick-quoted for safety.
+//
+// Examples:
+//
+//	FormatClusterName("'{cluster}'") → "'{cluster}'"
+//	FormatClusterName("default")     → "`default`"
+//	FormatClusterName("")            → ""
+func FormatClusterName(name string) string {
+	switch {
+	case name == "":
+		return ""
+	case IsClusterMacro(name):
+		return name
+	default:
+		return BacktickIdentifier(name)
+	}
 }
 
 // StripBackticks removes backticks from an identifier if present.

--- a/pkg/utils/identifier_test.go
+++ b/pkg/utils/identifier_test.go
@@ -274,3 +274,87 @@ func TestStripBackticks(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+func TestIsClusterMacro(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		// ClickHouse server macro references — single-quoted braces
+		{"'{cluster}'", true},
+		{"'{shard}'", true},
+		{"'{replica}'", true},
+		// Any single-quoted value is treated as a macro by the parser convention
+		{"'any-quoted-string'", true},
+		// Plain identifiers must NOT be treated as macros
+		{"default", false},
+		{"my-cluster", false},
+		{"`default`", false},
+		// Edge cases
+		{"", false},
+		{"'", false},  // not a valid single-quoted string (no closing quote)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, utils.IsClusterMacro(tc.input))
+		})
+	}
+}
+
+func TestIsClickHouseMacro(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		// Proper ClickHouse server macro syntax: '{identifier}'
+		{"'{cluster}'", true},
+		{"'{shard}'", true},
+		{"'{replica}'", true},
+		{"'{my_macro}'", true},
+		// Single-quoted strings without braces are NOT server macros
+		{"'any-quoted-string'", false},
+		{"'default'", false},
+		// Plain identifiers are not macros
+		{"default", false},
+		{"my-cluster", false},
+		{"`default`", false},
+		// Malformed macro patterns
+		{"'{}'", false},           // empty identifier
+		{"'{123bad}'", false},     // identifier starts with digit
+		{"'{cluster'", false},     // missing closing brace
+		{"'{cluster}x'", false},   // trailing content after brace
+		// Edge cases
+		{"", false},
+		{"'", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, utils.IsClickHouseMacro(tc.input))
+		})
+	}
+}
+
+func TestFormatClusterName(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// Macro references must be returned verbatim (no extra quoting)
+		{"'{cluster}'", "'{cluster}'"},
+		{"'{shard}'", "'{shard}'"},
+		// Plain identifiers must be backtick-quoted
+		{"default", "`default`"},
+		{"my-cluster", "`my-cluster`"},
+		{"prod", "`prod`"},
+		// Empty string — nothing to format
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.expected, utils.FormatClusterName(tc.input))
+		})
+	}
+}

--- a/pkg/utils/sqlbuilder.go
+++ b/pkg/utils/sqlbuilder.go
@@ -138,13 +138,17 @@ func (b *SQLBuilder) QualifiedName(database *string, name string) *SQLBuilder {
 
 // OnCluster adds an ON CLUSTER clause if cluster is not empty.
 //
+// Plain cluster names are backtick-quoted; ClickHouse macro references (e.g. '{cluster}')
+// are emitted verbatim so that generated migrations are portable across clusters.
+//
 // Example:
 //
-//	builder.OnCluster("production")  // ON CLUSTER `production`
-//	builder.OnCluster("")            // (nothing added)
+//	builder.OnCluster("production")   // ON CLUSTER `production`
+//	builder.OnCluster("'{cluster}'")  // ON CLUSTER '{cluster}'
+//	builder.OnCluster("")             // (nothing added)
 func (b *SQLBuilder) OnCluster(cluster string) *SQLBuilder {
 	if cluster != "" {
-		b.parts = append(b.parts, "ON", "CLUSTER", BacktickIdentifier(cluster))
+		b.parts = append(b.parts, "ON", "CLUSTER", FormatClusterName(cluster))
 	}
 	return b
 }


### PR DESCRIPTION
## Summary

`formatModifyColumn` wraps `*op.Comment` in extra single quotes:

```go
parts = append(parts, f.keyword("COMMENT"))
parts = append(parts, "'"+*op.Comment+"'")
```

But the `participle` `@String` token already includes its surrounding quotes, so the output ends up double-quoted:

```sql
ALTER TABLE `analytics`.`events`
    MODIFY COLUMN `metadata` String COMMENT ''Updated metadata column'';
```

That string is then invalid (well, it's an empty literal followed by a bareword in ClickHouse), and housekeeper's own parser rejects it when re-reading generated migrations — which breaks `diff` whenever a `MODIFY COLUMN` touches a comment.

## Fix

Drop the extra wrapping and emit `*op.Comment` verbatim, matching every other `COMMENT` site in the formatter (`formatColumnDefinition` lines 404 / 448, `formatDatabase` `MODIFY COMMENT`, `formatDictionary`, table-level `COMMENT`, etc., all of which already do this).

```go
if op.Comment != nil {
    parts = append(parts, f.keyword("COMMENT"), *op.Comment)
}
```

## Verification

* `go test ./pkg/format/ -count=1` — green (golden file `table_operations.sql` updated to drop the doubled quotes)
* `go test ./... -count=1` — green
* Round-trip: parse → format → parse again now succeeds for `ALTER TABLE … MODIFY COLUMN x T COMMENT 'foo'`.
